### PR TITLE
Added support for multiple sensors on a single OneWire bus.

### DIFF
--- a/devices/DS18B20.js
+++ b/devices/DS18B20.js
@@ -43,4 +43,4 @@ DS18B20.prototype.getTemp = function (/*optional*/verify) {
   temp = temp / 16.0;
   return temp;
 };
-exports.connect = function (pin, device) {return new DS18B20(pin, device);};
+exports.connect = function (oneWire, device) {return new DS18B20(oneWire, device);};


### PR DESCRIPTION
This is not only saving pins but should also use less memory for multiple sensors.

Functionally it is compatible with your implementation but logically it is different in that connect() returns a bus object instead of a sensor.
If you are happy with these changes then I can update documentation too. Here are some quick examples:

```
var sensorBus = require("DS18B20").connect(A1);
sensorBus.getTemp(); //gets reading from the first sensor
sensorBus.getSensors().length; //number of sensors
var kitchen = sensorBus.getSensors()[1];
sensorBus.getTemp(kitchen);
```
