### PR TITLE
Remove _mapRes() method

### DIFF
--- a/devices/DS18B20.js
+++ b/devices/DS18B20.js
@@ -53,7 +53,7 @@ DS18B20.prototype.setRes = function (res) {
   this._writeSpad(spad[2], spad[3], res);
 };
 DS18B20.prototype.getRes = function () {
-  return [9,10,11,12][(this._readSpad()[4] - 31) / 32];
+  return [0x1F,0x3F,0x5F,0x7F].indexOf(this._readSpad()[4]) + 9;
 };
 DS18B20.prototype.isPresent = function () {
   return this.bus.search().indexOf(this.sCode) !== -1;


### PR DESCRIPTION
Hi Gordon, here is an idea - save up about 35-40 vars (memory) by using some math formulas and removing fairly big chunk of code.

As a consequence, setting and getting conversion resolution will take longer, but it doesn't really matter because these operations are normally executed only a few times (if any) in your program. In contrast, memory savings are there all the time. Also if I correctly understand the way code gets executed in Espruino, this change would actually increase the performance for common operations like temperature reading.

What I don't like about this solution is that these formulas use a lot of magic numbers and so the code readability suffers... but that's the best working formulas I could come up with. Maybe some binary-ninja will jump in and improve them.
