### PR TITLE
Update Interfacing.md

### DIFF
--- a/tasks/Interfacing.md
+++ b/tasks/Interfacing.md
@@ -75,7 +75,7 @@ def espruino_cmd(command):
  )
  ser.open()
  ser.isOpen()
- ser.write(command+"n")
+ ser.write(command+"\n")
  endtime = time.time()+0.2 # wait 0.2 sec
  result = ""
  while time.time() < endtime:


### PR DESCRIPTION
corrected typo in the Python code: command should end with \n, not just n.
