### PR TITLE
Update Interfacing.md

### DIFF
--- a/tasks/Interfacing.md
+++ b/tasks/Interfacing.md
@@ -73,7 +73,6 @@ def espruino_cmd(command):
   bytesize=serial.EIGHTBITS,
   xonxoff=0, rtscts=0, dsrdtr=0,
  )
- ser.open()
  ser.isOpen()
  ser.write(command+"\n")
  endtime = time.time()+0.2 # wait 0.2 sec
@@ -107,4 +106,12 @@ $ ./espruino_command.py "print(analogRead(A0))"
 0.6546
 $ ./espruino_command.py "digitalWrite(LED1,1)"
 [no output, but turns the LED on]
+```
+
+To be able to communicate with the serial port using Python, you will need pySerial: [http://pyserial.sourceforge.net](http://pyserial.sourceforge.net) . If you run into the trouble that the code complains that it cannot find `serial`, you will first need to install pySerial, which is luckily very straightforward (example below assumes you have downloaded version 2.7, update the commands as appropriate):
+
+```
+tar xfvz pyserial-2.7.tar.gz
+cd pyserial-2.7
+sudo python setup.py install
 ```


### PR DESCRIPTION
Two more updates: 
- added instructions on installing pySerial, as that module is needed but commonly not installed;
- removed the ser.open(); upon object creation the port is immediately opened, so trying to open it will result in an error that the port is already open. This should be tested on other systems, but I think this behaviour is system independent.
