### PR TITLE
Correct typo in thermister example code

### DIFF
--- a/tutorials/Thermistors.md
+++ b/tutorials/Thermistors.md
@@ -56,7 +56,7 @@ Now our wiring is done, to the software! First off, we'll make the two pins eith
 
 ```
 digitalWrite(C0, 0);
-digitalWrite(C2, 0);
+digitalWrite(C2, 1);
 ```
 
 And we can read off the voltage:


### PR DESCRIPTION
The first two line bit of example code given for setting the two outer pins to gnd and +3.3v was setting both to 0.
