### PR TITLE
Fix regression in PCD8544.js

### DIFF
--- a/devices/PCD8544.js
+++ b/devices/PCD8544.js
@@ -41,7 +41,7 @@ exports.connect = function(/*=SPI*/_spi, /*=PIN*/_dc, /*=PIN*/_ce, /*=PIN*/_rst,
       spi.send(0x40|i, ce); // Y addr
       spi.send(0x80, ce); // X addr
       digitalWrite(dc,1); // data
-      spi.send(new Uint8Array(this.buffer,i*84,84), ce);
+      spi.send(new Uint8Array(this.buffer,i*84,84+2*(i<5)), ce);
     }
   };
   LCD.setContrast = function(c) { // c between 0 and 1. 0.5 is default


### PR DESCRIPTION
flip() was broken by https://github.com/espruino/EspruinoDocs/commit/0c7cd947c08e93020faae3e233d7d1bf97bb9fe3#diff-54e8aad38d317a8ea7e056d928e39c43 

It seems that you do need those two bytes at the end of each line - except on the last line, where they'll overwrite the first 2 bytes of the first line. Weird! Seems to work like this.
