### PR TITLE
Updated MPU6050 to allow I2C address selection

### DIFF
--- a/devices/MPU6050.js
+++ b/devices/MPU6050.js
@@ -129,10 +129,12 @@ var R = {
 };
 
 /* MPU6050 Object */
-function MPU6050(_i2c) {
+function MPU6050(_i2c, _addr) {
   this.i2c = _i2c;
-  this.addr = C.ADDRESS_AD0_LOW;
-
+  this.addr =
+    (undefined===_addr || false===_addr) ? C.ADDRESS_AD0_LOW :
+    (true===_addr) ? C.ADDRESS_AD0_HIGH :
+    _addr;
   this.initialize();
 }
 
@@ -244,6 +246,6 @@ MPU6050.prototype.getTemperature = function() {
   return this.readS16(R.TEMP_OUT_H) / 340 + 36.53;
 };
 
-exports.connect = function (_i2c) {
-  return new MPU6050(_i2c);
+exports.connect = function (_i2c,_addr) {
+  return new MPU6050(_i2c,_addr);
 };

--- a/devices/MPU6050.md
+++ b/devices/MPU6050.md
@@ -4,7 +4,7 @@ MPU6050 accelerometer and gyro
 
 * KEYWORDS: Module,I2C,IMU,MPU6050,MPU6000,gyro,gyroscope,Acceleration,accelerometer,motion
 
-The Invensense MPU6050 is a combined digital accelerometer and gyro. This module enables I2C communication with the chip to easily get accelation and rotaion data. Use the [MPU6050](/modules/MPU6050.js) ([About Modules](/Modules)) module for it.
+The Invensense MPU6050 is a combined digital accelerometer and gyro. This module enables I2C communication with the chip to easily get acceleration and rotation data. Use the [MPU6050](/modules/MPU6050.js) ([About Modules](/Modules)) module for it.
 
 You can wire this up as follows:
 
@@ -24,4 +24,11 @@ mpu.getAcceleration(); // returns an [x,y,z] array with raw accl. data
 mpu.getGravity();  // returns acceleration array in G's
 mpu.getRotation(); // returns an [x,y,z] array with raw gyro data
 mpu.getDegreesPerSecond(); // returns gyro array in degrees/s
+```
+
+For use of more than one chip per I2C bus, the address can be selected with an additional parameter to the `connect` call:
+
+```
+var mpu = require("MPU6050").connect(I2C1, false); // AD0 pin wired to GND
+var mpu = require("MPU6050").connect(I2C1, true); // AD0 pin wired to Vcc
 ```


### PR DESCRIPTION
For comparing relative orientation of two points, two accelerometers can be wired on the same bus with the address pin wired high or low.  The `_addr` parameter is optional, so existing code should not be affected.
