### PR TITLE
Update CC3000.md

### DIFF
--- a/devices/CC3000.md
+++ b/devices/CC3000.md
@@ -14,8 +14,9 @@ First off, you need to connect the module. Currently it **must** be on the follo
 
 |  CC3000  |  Espruino |
 |----------|-----------|
-| VCC/VIN  | VBAT      |
 | GND      | GND       |
+| 3v3      | Do not use |
+| VIN      | VBAT      |
 | CLK/SCK  | B3        |
 | DOUT/MISO| B4        |
 | DIN/MOSI | B5        |
@@ -24,7 +25,7 @@ First off, you need to connect the module. Currently it **must** be on the follo
 | IRQ      | B8        |
 
 
-**Note:** VCC on the CC3000 needs to be between 2.7V and 4.8V. On the Espruino Board, VBAT is 4.3v when running from USB and is the same as the battery voltage when plugged into a battery. This means that when running with single-cell LiPo batteries you'll be fine, **HOWEVER** the situation may be different on other boards.
+**Note:**  The voltage regulator on the Adafruit CC3000 module will work with voltages as high as 18V on VIN. If using a *different* breakout board, you must be sure that the voltage applied to the CC3000 (Vcc) is between 2.7 and 4.8v. On the Espruino Board, VBAT is 4.3v when running from USB and is the same as the battery voltage when plugged into a battery.
 
 Using the CC3000 is as follows:
 


### PR DESCRIPTION
Clarified bit about VCC on the CC3k - I hope this is what you meant. 

Also modified the connection chart so it shows the pins in the order they're on the module in. 

Per https://forums.adafruit.com/viewtopic.php?f=19&t=51006 the Adafruit module includes a regulator that can take up to 18v - I think the bit about 2.7-4.8v was leading to confusion (with people trying to power the board off of the Espruino's 3.3v, which can't take it).
