### PR TITLE
MQTT module

### DIFF
--- a/devices/MQTT.js
+++ b/devices/MQTT.js
@@ -119,15 +119,15 @@ MQTT.prototype.connect = function(client) {
       if(type === TYPE.PUBLISH) {
         mqo.emit('publish', mqo.parsePublish(data));
       }
-      // else if(type === TYPE.PUBACK) {
-      //   // implement puback
-      // }
-      // else if(type === TYPE.SUBACK) {
-      //   // implement suback
-      // }
-      // else if(type === TYPE.UNSUBACK) {
-      //   // implement unsuback
-      // }
+      else if(type === TYPE.PUBACK) {
+        // implement puback
+      }
+      else if(type === TYPE.SUBACK) {
+        // implement suback
+      }
+      else if(type === TYPE.UNSUBACK) {
+        // implement unsuback
+      }
       else if(type === TYPE.PINGREQ) {
         // silently reply to pings
         client.write(TYPE.PINGRESP+"\x00"); // reply to PINGREQ
@@ -160,7 +160,7 @@ MQTT.prototype.connect = function(client) {
     
     mqo.client = client;
   };
-  if (client) onConnect(client);
+  if (client) onConnect();
   else client = require("net").connect({host : mqo.server, port: mqo.port}, onConnect);
 };
 

--- a/devices/MQTT.js
+++ b/devices/MQTT.js
@@ -95,9 +95,9 @@ MQTT.prototype.mqttUid = (function() {
 /* Public interface ****************************/
 
 /** Establish connection and set up keep_alive ping */
-MQTT.prototype.connect = function() {
+MQTT.prototype.connect = function(client) {
   var mqo = this;
-  var client = require("net").connect({host : mqo.server, port: mqo.port}, function() {
+  var onConnect = function() {
     console.log('Client connected');
     client.write(mqo.mqttConnect(mqo.client_id));
 
@@ -119,15 +119,15 @@ MQTT.prototype.connect = function() {
       if(type === TYPE.PUBLISH) {
         mqo.emit('publish', mqo.parsePublish(data));
       }
-      else if(type === TYPE.PUBACK) {
-        // implement puback
-      }
-      else if(type === TYPE.SUBACK) {
-        // implement suback
-      }
-      else if(type === TYPE.UNSUBACK) {
-        // implement unsuback
-      }
+      // else if(type === TYPE.PUBACK) {
+      //   // implement puback
+      // }
+      // else if(type === TYPE.SUBACK) {
+      //   // implement suback
+      // }
+      // else if(type === TYPE.UNSUBACK) {
+      //   // implement unsuback
+      // }
       else if(type === TYPE.PINGREQ) {
         // silently reply to pings
         client.write(TYPE.PINGRESP+"\x00"); // reply to PINGREQ
@@ -159,7 +159,9 @@ MQTT.prototype.connect = function() {
     });
     
     mqo.client = client;
-  });
+  };
+  if (client) onConnect(client);
+  else client = require("net").connect({host : mqo.server, port: mqo.port}, onConnect);
 };
 
 /** Disconnect from server */

--- a/devices/MQTT.js
+++ b/devices/MQTT.js
@@ -164,13 +164,13 @@ MQTT.prototype.disconnect = function(topic, message) {
 
 /** Publish message using specified topic */
 MQTT.prototype.publish = function(topic, message, qos) {
-  var _qos = qos || this.C.DEF_QOS;
+  var _qos = qos || this.C.DEF_QOS;
   this.client.write(this.mqttPublish(topic, message, _qos));
 };
 
 /** Subscribe to topic (filter) */
 MQTT.prototype.subscribe = function(topic, qos) {
-  var _qos = qos || this.C.DEF_QOS;
+  var _qos = qos || this.C.DEF_QOS;
   this.client.write(this.mqttSubscribe(topic, _qos));
 };
 

--- a/devices/MQTT.js
+++ b/devices/MQTT.js
@@ -122,6 +122,12 @@ MQTT.prototype.connect = function() {
       else if(type === TYPE.PUBACK) {
         // implement puback
       }
+      else if(type === TYPE.SUBACK) {
+        // implement suback
+      }
+      else if(type === TYPE.UNSUBACK) {
+        // implement unsuback
+      }
       else if(type === TYPE.PINGREQ) {
         // silently reply to pings
         client.write(TYPE.PINGRESP+"\x00"); // reply to PINGREQ

--- a/devices/MQTT.js
+++ b/devices/MQTT.js
@@ -1,0 +1,238 @@
+/* Copyright (c) 2014 Lars Toft Jacobsen (boxed.dk). See the file LICENSE for copying permission. */
+/*
+Simple MQTT protocol wrapper for Espruino sockets.
+*/
+
+/** 'private' costants */
+var C = {
+  PACKET_ID      : 1,     // Bad...fixed packet id
+  PROTOCOL_LEVEL : "\x04" // MQTT protocol level
+}
+
+/** Control packet types */
+var TYPE = {
+  CONNECT     :  1,
+  CONNACK     :  2,
+  PUBLISH     :  3,
+  PUBACK      :  4,
+  PUBREC      :  5,
+  PUBREL      :  6,
+  PUBCOMP     :  7,
+  SUBSCRIBE   :  8,
+  SUBACK      :  9,
+  UNSUBSCRIBE : 10,
+  UNSUBACK    : 11,
+  PINGREQ     : 12,
+  PINGRESP    : 13,
+  DISCONNECT  : 14
+};
+
+/** MQTT constructor */ 
+function MQTT(server, options) {
+  this.server = server;
+  var options = options || {};
+  this.port = options.port || this.C.DEF_PORT;
+  this.client_id = options.client_id || this.mqttUid();
+  this.keep_alive = options.keep_alive || this.C.DEF_KEEP_ALIVE;
+  this.clean_session = options.clean_session || true;
+  this.client = false;
+  this.connected = false;
+  this.ping_interval = 
+    this.keep_alive < this.C.PING_INTERVAL ? (this.keep_alive - 5) : this.C.PING_INTERVAL;
+}
+
+/** 'public' constants here */
+MQTT.prototype.C = {
+  DEF_QOS         : 0,    // Default QOS level
+  DEF_PORT        : 1883, // MQTT default server port
+  DEF_KEEP_ALIVE  : 60,   // Default keep_alive (s)
+  CONNECT_TIMEOUT : 5000, // Time (s) to wait for CONNACK 
+  PING_INTERVAL   : 40    // Server ping interval (s)
+};
+
+/* Utility functions ***************************/
+
+/** MQTT string (length MSB, LSB + data) */
+MQTT.prototype.mqttStr = function(s) {
+  return String.fromCharCode(s.length>>8, s.length&255)+s;
+};
+
+/** MQTT standard packet formatter */
+MQTT.prototype.mqttPacket = function(cmd, variable, payload) {
+  return String.fromCharCode(cmd, variable.length+payload.length)+variable+payload;
+};
+
+/** PUBLISH packet parser - returns object with topic and message */
+MQTT.prototype.parsePublish = function(data) {
+  if (data.length > 5 && typeof data !== undefined) {
+    var cmd = data.charCodeAt(0);
+    var rem_len = data.charCodeAt(1);
+    var var_len = data.charCodeAt(2) << 8 | data.charCodeAt(3);
+    return { topic: data.substr(4, var_len),
+             message: data.substr(4+var_len, rem_len-var_len),
+             dup: (cmd & 0b00001000) >> 3,
+             qos: (cmd & 0b00000110) >> 1,
+             retain: cmd & 0b00000001
+           };
+  }
+  else {
+    return undefined;
+  }
+};
+
+/** Generate random UID */
+MQTT.prototype.mqttUid = (function() {
+  function s4() {
+    return Math.floor((1 + Math.random()) * 0x10000)
+               .toString(16)
+               .substring(1);
+  }
+  return function() {
+    return s4() + '-' + s4();
+  };
+})();
+
+/* Public interface ****************************/
+
+/** Establish connection and set up keep_alive ping */
+MQTT.prototype.connect = function() {
+  var mqo = this;
+  var client = require("net").connect({host : mqo.server, port: mqo.port}, function() {
+    console.log('Client connected');
+    client.write(mqo.mqttConnect(mqo.client_id));
+
+    // Disconnect if no CONNACK is received
+    mqo.ctimo = setTimeout(function() {
+      mqo.disconnect();
+    }, mqo.C.CONNECT_TIMEOUT);
+
+    // Set up regular keep_alive ping
+    mqo.pintr = setInterval(function() {
+      // console.log("Pinging MQTT server");
+      mqo.ping();
+    }, mqo.ping_interval*1000);
+    
+    // Incoming data
+    client.on('data', function(data) {
+      var type = data.charCodeAt(0) >> 4;
+
+      if(type === TYPE.PUBLISH) {
+        mqo.emit('publish', mqo.parsePublish(data));
+      }
+      else if(type === TYPE.PUBACK) {
+        // implement puback
+      }
+      else if(type === TYPE.PINGREQ) {
+        // silently reply to pings
+        client.write(TYPE.PINGRESP+"\x00"); // reply to PINGREQ
+      }
+      else if(type === TYPE.PINGRESP) {
+        mqo.emit('ping_reply');
+      }
+      else if(type === TYPE.CONNACK) {
+        clearTimeout(mqo.ctimo);
+        if(data.charCodeAt(3) === 0) {
+          mqo.connected = true;
+          console.log("MQTT connection accepted");
+        }
+        else {
+          console.log("MQTT connection error");
+        }
+      }
+      else {
+        Console.log("MQTT unsupported packet type: "+type);
+        Console.log("[MQTT]"+data.split("").map(function(c) { return c.charCodeAt(0); }));
+      }
+    });
+
+    client.on('end', function() {
+      console.log('MQTT client disconnected');
+      clearInterval(mqo.pintr);
+    });
+    
+    mqo.client = client;
+  });
+};
+
+/** Disconnect from server */
+MQTT.prototype.disconnect = function(topic, message) {
+  this.client.write(String.fromCharCode(TYPE.DISCONNECT<<4)+"\x00");
+  this.client.end();
+  this.client = false;
+  this.connected = false;
+};
+
+/** Publish message using specified topic */
+MQTT.prototype.publish = function(topic, message, qos) {
+  var _qos = qos || this.C.DEF_QOS;
+  this.client.write(this.mqttPublish(topic, message, _qos));
+};
+
+/** Subscribe to topic (filter) */
+MQTT.prototype.subscribe = function(topic, qos) {
+  var _qos = qos || this.C.DEF_QOS;
+  this.client.write(this.mqttSubscribe(topic, _qos));
+};
+
+/** Unsubscribe to topic (filter) */
+MQTT.prototype.unsubscribe = function(topic) {
+  this.client.write(this.mqttUnsubscribe(topic));
+};
+
+/** Send ping request to server */
+MQTT.prototype.ping = function() {
+  this.client.write(String.fromCharCode(TYPE.PINGREQ<<4)+"\x00");
+};
+
+/* Packet specific functions *******************/
+
+/** CONNECT control packet 
+    Clean Session is currently only supported
+    connect flag. Wills and user/pass is not
+    currently supported.
+*/
+MQTT.prototype.mqttConnect = function(clean) {
+  var cmd = TYPE.CONNECT << 4;
+  var flags = clean !== undefined && clean ? "\x02" : "\x00"; 
+  var keep_alive = String.fromCharCode(this.keep_alive>>8, this.keep_alive&255);
+  return this.mqttPacket(cmd, 
+           this.mqttStr("MQTT")/*protocol name*/+
+           C.PROTOCOL_LEVEL/*protocol level*/+
+           flags+
+           keep_alive, this.mqttStr(this.client_id));
+};
+
+/** PUBLISH control packet */
+MQTT.prototype.mqttPublish = function(topic, message, qos) {
+  var cmd = TYPE.PUBLISH << 4 | (qos << 1);
+  var pid = String.fromCharCode(C.PACKET_ID<<8, C.PACKET_ID&255);
+  // Packet id must be included for QOS > 0
+  var variable = (qos === 0) ? this.mqttStr(topic) : this.mqttStr(topic)+pid;
+  return this.mqttPacket(cmd, variable, message);
+};
+
+/** SUBSCRIBE control packet */
+MQTT.prototype.mqttSubscribe = function(topic, qos) {
+  var cmd = TYPE.SUBSCRIBE << 4 | 2;
+  var pid = String.fromCharCode(C.PACKET_ID<<8, C.PACKET_ID&255);
+  return this.mqttPacket(cmd,
+           pid/*Packet id*/,
+           this.mqttStr(topic)+
+           String.fromCharCode(qos)/*QOS*/);
+};
+
+/** UNSUBSCRIBE control packet */
+MQTT.prototype.mqttUnsubscribe = function(topic) {
+  var cmd = TYPE.UNSUBSCRIBE << 4 | 2;
+  var pid = String.fromCharCode(C.PACKET_ID<<8, C.PACKET_ID&255);
+  return this.mqttPacket(cmd,
+           pid/*Packet id*/,
+           this.mqttStr(topic));
+};
+
+/* Exports *************************************/
+
+/** This is 'exported' so it can be used with `require('MQTT.js').create(server, options)` */
+exports.create = function (server, options) {
+  return Object.create(new MQTT(server, options));
+};

--- a/devices/MQTT.js
+++ b/devices/MQTT.js
@@ -140,6 +140,7 @@ MQTT.prototype.connect = function() {
         if(data.charCodeAt(3) === 0) {
           mqo.connected = true;
           console.log("MQTT connection accepted");
+          mqo.emit('connected');
         }
         else {
           console.log("MQTT connection error");
@@ -154,6 +155,7 @@ MQTT.prototype.connect = function() {
     client.on('end', function() {
       console.log('MQTT client disconnected');
       clearInterval(mqo.pintr);
+      mqo.emit('disconnected');
     });
     
     mqo.client = client;

--- a/devices/MQTT.js
+++ b/devices/MQTT.js
@@ -140,8 +140,8 @@ MQTT.prototype.connect = function() {
         }
       }
       else {
-        Console.log("MQTT unsupported packet type: "+type);
-        Console.log("[MQTT]"+data.split("").map(function(c) { return c.charCodeAt(0); }));
+        console.log("MQTT unsupported packet type: "+type);
+        console.log("[MQTT]"+data.split("").map(function(c) { return c.charCodeAt(0); }));
       }
     });
 

--- a/devices/MQTT.md
+++ b/devices/MQTT.md
@@ -1,0 +1,62 @@
+<!--- Copyright (c) 2014 Lars Toft Jacobsen (boxed.dk). See the file LICENSE for copying permission. -->
+MQTT Client
+=====================
+
+* KEYWORDS: Module,MQTT,protocol,client
+
+A very simple [MQTT](http://mqtt.org/) client implementation for Espruino based on the original socket example by Gordon in this [forum post](http://forum.espruino.com/conversations/258515/). MQTT is a lightweight publish-subscribe protocol built for reliable machine-2-machine communication with a very small footprint. It provides efficient and robust communication mechanisms as well as QOS. This module is however a work-in-progress and only a subset of the protocol is implemented. Likewise there's no guarantee that the implementation complies 100% with the MQTT specification. As of now only QOS 0 (at most once) is truly supported. Encryption and authentication is not supported. The module has been tested with Mosquitto-1.3.5. Use the [MQTT](/modules/MQTT.js) ([About Modules](/Modules)) module for it.
+
+The module exports the function create(server, options) that returns a new MQTT object using the provided arguments. The server argument is the MQTT broker ip address, and options is an optional object that can used to pass non-default parameters: keep_alive, port, and clean_session. If not provided these will default to 60 s, 1883 and true respectively.
+
+Setting up and connecting:
+
+First of load the module and create a MQTT object using ```require("MQTT").create(server)```. The module can oly be used with a network connection. In the example below th CC3000 is used to setup a network connection and get a DHCP address. Upon a successful connection connect to the MQTT broker by calling ```connect()```. This will open a socket connection to the server and establish MQTT communications. The client will ping the server every 40 seconds to keep the connection alive in case no other control packets are sent.
+
+```
+  var server = "192.168.1.10"; // the ip of your MQTT broker
+  var mqtt = require("MQTT").create(server);
+
+  var wlan = require("CC3000").connect();
+  wlan.connect( "AccessPointName", "WPA2key", function (s) { 
+    if (s=="dhcp") {
+      console.log("My IP is "+wlan.getIP().ip);
+      mqtt.connect();
+    }
+  });
+```
+
+Disconnect
+-----------
+
+If for some reason you want to disconnect and close the socket use the ```disconnect()``` function.
+
+```
+  mqtt.disconnect();
+```
+
+Publish
+-----------
+
+At any time during a session you can publish a message to the broker. A topic must be provided to allow the broker to deliver the message to any client with a subscription that matches that topic.
+```
+  var topic = "test/espruino";
+  var message = "hello, world";
+  mqtt.publish(topic, message);
+```
+
+Subscribe/Unsubscribe
+-----------
+
+Subscriptions are managed using the ```subscribe(topic_filter)``` and ```unsubscribe(topic_filter)```functions. A topic filter can be just a specific topic or contain wildcards that matches groups and/or sub-groups of topics. An event, publish, is fired whenever a message is recieved by the client. The event emitter calls the listener with an object containin all the relevant packet information: topic, message, (dup, qos and retain).
+
+```
+  mqtt.subscribe("test/espruino");
+
+  mqtt.on('publish', function (pub) {
+    console.log("topic: "+pub.topic);
+    console.log("message: "+pub.message);
+  });
+
+  mqtt.unsubscribe("test/epruino");
+```
+

--- a/devices/MQTT.md
+++ b/devices/MQTT.md
@@ -6,15 +6,19 @@ MQTT Client
 
 A very simple [MQTT](http://mqtt.org/) client implementation for Espruino based on the original socket example by Gordon in this [forum post](http://forum.espruino.com/conversations/258515/). MQTT is a lightweight publish-subscribe protocol built for reliable machine-2-machine communication with a very small footprint. It provides efficient and robust communication mechanisms as well as QOS. This module is however a work-in-progress and only a subset of the protocol is implemented. Likewise there's no guarantee that the implementation complies 100% with the MQTT specification. As of now only QOS 0 (at most once) is truly supported. Encryption and authentication is not supported. The module has been tested with Mosquitto-1.3.5. Use the [MQTT](/modules/MQTT.js) ([About Modules](/Modules)) module for it.
 
-The module exports the function create(server, options) that returns a new MQTT object using the provided arguments. The server argument is the MQTT broker ip address, and options is an optional object that can used to pass non-default parameters: keep_alive, port, and clean_session. If not provided these will default to 60 s, 1883 and true respectively.
+The module exports the function create(server, options) that returns a new MQTT object using the provided arguments. The server argument is the MQTT broker ip address, and options is an optional object that can used to pass non-default parameters: client_id, keep_alive, port, and clean_session. If not provided these will default to, a random GUID, 60 s, 1883 and true respectively. Provide a hard-coded client id to ensure the Espruino will always present itself using the same id after a reset.
 
 Setting up and connecting:
 
-First of load the module and create a MQTT object using ```require("MQTT").create(server)```. The module can oly be used with a network connection. In the example below th CC3000 is used to setup a network connection and get a DHCP address. Upon a successful connection connect to the MQTT broker by calling ```connect()```. This will open a socket connection to the server and establish MQTT communications. The client will ping the server every 40 seconds to keep the connection alive in case no other control packets are sent.
+First of load the module and create a MQTT object using ```require("MQTT").create(server)```. The module can oly be used with a network connection. In the example below th CC3000 is used to setup a network connection and get a DHCP address. Upon a successful connection connect to the MQTT broker by calling ```connect()```. This will open a socket connection to the server and establish MQTT communications. The client will ping the server every 40 seconds to keep the connection alive in case no other control packets are sent. The connected event can be used to set up subscriptions etc. upon sucessful connection.
 
 ```
   var server = "192.168.1.10"; // the ip of your MQTT broker
   var mqtt = require("MQTT").create(server);
+
+  mqtt.on('connected', function() {
+    mqtt.subscribe("test");
+  });
 
   var wlan = require("CC3000").connect();
   wlan.connect( "AccessPointName", "WPA2key", function (s) { 


### PR DESCRIPTION
Hey Gordon,

Based on and inspired by your socket/MQTT example I have created a MQTT client module that implements a protocol subset and some crude approximations. It's a work in progress and lacks a lot but it adds publish, subscribe, unsubscribe, connect and disconnect and wraps it up in a nice module with a publish event for ease of use. I'll continue to work on it and also look into a more complete implementation (maybe a port of the Eclipse PAHO JS client).

Cheers,
Lars