### PR TITLE
Append links to eeprom example, add ebay buying links to device docs

### DIFF
--- a/devices/ADXL335.md
+++ b/devices/ADXL335.md
@@ -32,4 +32,5 @@ Buying
 
 ADXL335 modules can be purchased from many places:
 
+* [eBay](http://www.ebay.com/sch/i.html?_nkw=ADXL335&_sacat=92074)
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=adxl335)

--- a/devices/ADXL345.md
+++ b/devices/ADXL345.md
@@ -174,5 +174,5 @@ Buying
 -----
 
 ADXL345 modules can be purchased from many places:
-
+* [eBay](http://www.ebay.com/sch/i.html?_nkw=ADXL345&_sacat=92074)
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=adxl345)

--- a/devices/BH1750.md
+++ b/devices/BH1750.md
@@ -76,3 +76,4 @@ Buying
 BH1750 sensors can be purchased from many places:
 
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=bh1750)
+* [eBay](http://www.ebay.com/sch/i.html?_nkw=bh1750fvi&_sacat=92074)

--- a/devices/BMP085.md
+++ b/devices/BMP085.md
@@ -77,8 +77,4 @@ Buying
 BMP085 sensors can be purchased from many places:
 
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=bmp085)
-
-
-BMP180 sensors can be purchased from many places:
-
-* [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=bmp180)
+* [eBay](http://www.ebay.com/sch/i.html?_nkw=BMP180&_sacat=92074)

--- a/devices/BMP085.md
+++ b/devices/BMP085.md
@@ -76,5 +76,5 @@ Buying
 
 BMP085 sensors can be purchased from many places:
 
-* [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=bmp085)
+* [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=bmp180)
 * [eBay](http://www.ebay.com/sch/i.html?_nkw=BMP180&_sacat=92074)

--- a/devices/BMP085.md
+++ b/devices/BMP085.md
@@ -4,7 +4,7 @@ BMP085/BMP180 digital pressure sensor
 
 * KEYWORDS: Module,I2C,BMP085,BMP180,pressure,temperature,altitude,sensor
 
-This is a small module that makes it easy to connect to a BMP085 or BMP180 digital pressure sensore using I2C.
+This is a small module that makes it easy to connect to a BMP085 or BMP180 digital barometric pressure sensor using I2C.
 Use the [BMP085](/modules/BMP085.js) ([About Modules](/Modules)) module for it.
 
 You can wire this up as follows:
@@ -76,5 +76,5 @@ Buying
 
 BMP085 sensors can be purchased from many places:
 
-* [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=bmp180)
+* digitalmeans.co.uk [BMP180](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=bmp180), [BMP085](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=bmp085)
 * [eBay](http://www.ebay.com/sch/i.html?_nkw=BMP180&_sacat=92074)

--- a/devices/DHT11.md
+++ b/devices/DHT11.md
@@ -53,6 +53,6 @@ For example:
 Buying
 -----
 
-DHT11 modules can be purchased from many places:
-
+DHT11 parts and modules can be purchased from many places:
+* [eBay](http://www.ebay.com/sch/i.html?_nkw=DHT11&_sacat=92074)
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=dht11)

--- a/devices/DHT22.md
+++ b/devices/DHT22.md
@@ -48,6 +48,6 @@ For example:
 Buying
 -----
 
-DHT22 modules can be purchased from many places:
-
+DHT22 parts and modules can be purchased from many places:
+* [eBay](http://www.ebay.com/sch/i.html?_nkw=DHT22&_sacat=92074)
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=dht22)

--- a/devices/HD44780.md
+++ b/devices/HD44780.md
@@ -146,5 +146,5 @@ Using
 
 Buying
 -----
-
+* [eBay](http://www.ebay.com/sch/i.html?_nkw=HD44780&_sacat=92074)
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=hd44780)

--- a/devices/HMC5883.md
+++ b/devices/HMC5883.md
@@ -117,5 +117,5 @@ The measurement is returned as an object with properties overflow, x, y, and z. 
 
 Buying
 -----
-
+* [eBay](http://www.ebay.com/sch/i.html?_nkw=HMC5883&_sacat=92074)
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=hmc5883)

--- a/devices/MAX31855.md
+++ b/devices/MAX31855.md
@@ -40,6 +40,6 @@ console.log(max.getTemp());
 Buying
 -----
 
-The MAX31855 can be purchased from many places including:
-
+The MAX31855 is a very common part, and is widely available. Be sure to get the right variant of it for the type of thermocouple that you plan to use.
+* [eBay](http://www.ebay.com/sch/i.html?_nkw=MAX31855&_sacat=92074)
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=max31855)

--- a/devices/MPU6050.md
+++ b/devices/MPU6050.md
@@ -36,6 +36,6 @@ var mpu = require("MPU6050").connect(I2C1, true); // AD0 pin wired to Vcc
 Buying
 -----
 
-MPU6050 can be purchased from many places:
-
+MPU6050 is a common and inexpensive part, and can be purchased from many places:
+* [eBay](http://www.ebay.com/sch/i.html?_nkw=MPU6050&_sacat=92074)
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=mpu6050)

--- a/devices/SmartNixie.md
+++ b/devices/SmartNixie.md
@@ -78,6 +78,6 @@ nixie.send();
 Buying
 -----
 
-You can get the Nixie from several different places, including:
+SmartNixie build kits can be purchased from the manufacturer:
 
-* [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=nixie)
+* [switchmodedesign.com](http://switchmodedesign.com/collections/arduino-shields/products/smart-nixie-tube)

--- a/devices/TSL2561.md
+++ b/devices/TSL2561.md
@@ -52,5 +52,5 @@ Buying
 -----
 
 You can get this sensor from several different places, including:
-
+* [eBay](http://www.ebay.com/sch/i.html?_nkw=TSL2561&_sacat=92074)
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=tsl2561)

--- a/devices/Thermistor.md
+++ b/devices/Thermistor.md
@@ -83,6 +83,6 @@ If you find the code returns NaN.  Check that you have used ``" " ``around the t
 Buying
 -----
 
-You can get this sensor from several different places, including:
-
+Thermistors are readily available from any electronics supplier, as well as other hobby sources like eBay.
+* [eBay](http://www.ebay.com/sch/i.html?_nkw=thermistor&_sacat=92074)
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=thermistor)

--- a/devices/WS2811.md
+++ b/devices/WS2811.md
@@ -89,9 +89,9 @@ Using
 Buying
 -----
 
-WS2811/WS2812 can be purchased from many places:
+WS2811/WS2812Bs can be purchased from many places, as bare parts (not recommended unless you're making your own PCBs), single lights on a breakout board, matrices, and long flexible strips (not to be confused with very similar strips that are not individually addressable). Although WS2811 and WS2812/2812B are different parts, the numbers are used interchangabley in product advertisements. Some sources:
 
 * [eBay](http://www.ebay.com/sch/i.html?_nkw=WS2811)
-* As [[RGB123]] matrices
+* As [[RGB123]] matrices from [RGB-123](http://rgb-123.com)
 * As [AdaFruit Neopixels](http://www.adafruit.com/index.php?main_page=adasearch&q=neopixel)
 * [digitalmeans.co.uk](https://digitalmeans.co.uk/shop/index.php?route=product/search&tag=ws2812)

--- a/examples/run_code_from_eeprom.md
+++ b/examples/run_code_from_eeprom.md
@@ -142,3 +142,6 @@ Conclusions and extensions
 
 This is an example of a very basic system for running snippets of code from an EEPROM. There is much room for improvement in addFunction(), which could be extended to look for an empty memory location to store the code in. Particularly with large EEPROMs, the index could be expanded, allowing a short string to "name" each entry. The data could be read as strings, and combined with named entries, you could have a string indexed data store on an EEPROM. You could store the index and data on different EEPROM chips, or add support for using multiple EEPROMs to store data - maybe you want to read the index quickly, and not worry about write endurance from regularly rewriting the index, and choose to use an FRAM chip for the index, instead of a traditional EEPROM. The possibilities are endless!
 
+Related Documents
+------
+* APPEND_KEYWORD: EEPROM


### PR DESCRIPTION
Recently some one who surely had no conflict of interest at all, went through and added buying links to all the device docs, linking to one specific vendor, digitalmeans, whose prices are exorbitant (except in the case where the site didn't actually sell the device). So everyone who read the pages was getting links suggesting that these parts cost 5-10x what they're available for from china-via-ebay. 

In each place where there weren't other vendors, I added an ebay link (to a search for the part number within the  business and industrial -> electronic and test equipment section, so readers get to see more than one source, at least one of which has the product at reasonable prices.