### PR TITLE
Stops Hanging Code if INIT failed

### DIFF
--- a/devices/BMP085.js
+++ b/devices/BMP085.js
@@ -38,7 +38,7 @@ function BMP085(/*=I2C*/_i2c, _mode) {
 
   var id = this.read8(0xD0);
   if(id != 0x55) {
-    console.log("Bad ID");
+    console.log("Bad ID of:" + id);
   }
   this.readCoefficients();
 }

--- a/devices/BMP085.js
+++ b/devices/BMP085.js
@@ -38,9 +38,12 @@ function BMP085(/*=I2C*/_i2c, _mode) {
 
   var id = this.read8(0xD0);
   if(id != 0x55) {
-    console.log("Bad ID of:" + id);
+    console.log("Bad ID of: " + id);
   }
-  this.readCoefficients();
+  else
+  {
+    this.readCoefficients();
+  }
 }
 
 /* Read 2 bytes from register reg

--- a/devices/BMP085.js
+++ b/devices/BMP085.js
@@ -39,11 +39,9 @@ function BMP085(/*=I2C*/_i2c, _mode) {
   var id = this.read8(0xD0);
   if(id != 0x55) {
     console.log("Bad ID of: " + id);
+    return null;
   }
-  else
-  {
     this.readCoefficients();
-  }
 }
 
 /* Read 2 bytes from register reg


### PR DESCRIPTION
Swift change to stop hanging if init failed (eg bad ID). and returns Null, so you don't get an object nocking around that cant do anything with.