### PR TITLE
CAP1188 breakout module

### DIFF
--- a/devices/CAP1188.js
+++ b/devices/CAP1188.js
@@ -1,0 +1,105 @@
+/* Copyright (c) 2015 Andrew Nicolaou. See the file LICENSE for copying permission. */
+/*
+  Module for Adafruit CAP1188 8-Key Capacitive Touch Sensor Breakout
+  Only I2C is supported.
+
+  See: https://www.adafruit.com/products/1602
+  Bit writing code from: http://www.espruino.com/modules/MPU6050.js
+  Influenced by Adafruit's CAP1188: https://github.com/adafruit/Adafruit_CAP1188_Library
+*/
+var C = {
+  ADDRESS_DEFAULT       : 0x29
+};
+
+/* Register addresses*/
+var R = {
+  MAIN_CONTROL          : 0x00,
+  SENSOR_INPUT_STATUS   : 0x03,
+  MULTI_TOUCH_CONFIG    : 0x2a,
+  STANDBY_CONFIG        : 0x41,
+  SENSOR_INPUT_LINKING  : 0x72,
+  LED_OUTPUT_CONTROL    : 0x74
+};
+
+/* Bits within register for functions */
+var B = {
+  MAIN_CONTROL_INT      : 0x0
+};
+
+function CAP1188(_i2c, _addr) {
+  this.i2c = _i2c;
+  this.addr = (undefined===_addr) ? C.ADDRESS_DEFAULT : _addr;
+  this.initialize();
+}
+
+/* Initialize the chip */
+CAP1188.prototype.initialize = function() {
+  this.linkLedsToSensors();
+  this.multipleTouches(true);
+  // "Speed up a bit"
+  this.i2c.writeTo(this.addr, [R.STANDBY_CONFIG, 0x30]);
+};
+
+/* How many simultaneous touches to allow */
+CAP1188.prototype.multipleTouches = function(enable) {
+  // 1 will block multiple touches
+  this.writeBit(R.MULTI_TOUCH_CONFIG, 7, enable ? 0 : 1);
+};
+
+/* Link the LED to corresponding sensor */
+CAP1188.prototype.linkLedsToSensors = function() {
+  for(var i = 0; i < 8; i++) {
+    this.linkLedToSensor(i, 1);
+  }
+};
+
+/* Link LED pin to sensor */
+CAP1188.prototype.linkLedToSensor = function(num, enable) {
+  this.writeBit(R.SENSOR_INPUT_LINKING, num, enable);
+};
+
+/* Read state of all sensors */
+CAP1188.prototype.readTouches = function() {
+  var touches = [],
+      raw;
+
+  this.i2c.writeTo(this.addr, R.SENSOR_INPUT_STATUS);
+  raw = this.i2c.readFrom(this.addr, 1)[0];
+
+  if (raw) {
+    // Clear interrupt to be able to read again
+    this.writeBit(R.MAIN_CONTROL, B.MAIN_CONTROL_INT, 0);
+  }
+
+  for(var i = 0; i < 8; i++) {
+    touches[i] = this.getBit(raw, i);
+  }
+
+
+  return touches;
+};
+
+/*  */
+CAP1188.prototype.getBit = function(byte, position) {
+  return (1 == ((byte >> position) & 1));
+};
+
+/* Set a single bit in a register */
+CAP1188.prototype.writeBit = function(reg, bit, val) {
+  this.i2c.writeTo(this.addr, reg);
+  var b = this.i2c.readFrom(this.addr, 1)[0];
+  b = (val !== 0) ? (b | (1 << bit)) : (b & ~(1 << bit));
+  this.i2c.writeTo(this.addr, [reg, b]);
+};
+
+/* Set more bits in a register */
+CAP1188.prototype.writeBits = function(reg, shift, val) {
+  this.i2c.writeTo(this.addr, reg);
+  var b = this.i2c.readFrom(this.addr, 1)[0];
+  b = b | (val << shift);
+  this.i2c.writeTo(this.addr, [reg, b]);
+};
+
+exports.connect = function (_i2c,_addr) {
+  return new CAP1188(_i2c,_addr);
+};

--- a/devices/CAP1188.js
+++ b/devices/CAP1188.js
@@ -80,8 +80,8 @@ CAP1188.prototype.readTouches = function() {
 };
 
 /*  */
-CAP1188.prototype.getBit = function(byte, position) {
-  return (1 == ((byte >> position) & 1));
+CAP1188.prototype.getBit = function(byt, position) {
+  return (1 == ((byt >> position) & 1));
 };
 
 /* Set a single bit in a register */

--- a/devices/CAP1188.md
+++ b/devices/CAP1188.md
@@ -1,0 +1,31 @@
+<!--- Copyright (c) 2015 Andrew Nicolaou. See the file LICENSE for copying permission. -->
+CAP1188 capacitive touch breakout
+=================================
+
+* KEYWORDS: Module,I2C,capacitive,touch
+
+The CAP1188 is an 8-channel capacitive touch sensor and is available in a handy [breakout board](https://www.adafruit.com/products/1602). This module enables I2C communication with the chip to easily get information about which pins are being touched. It's based on [Adafruit CAP1188 Arduino libary](https://github.com/adafruit/Adafruit_CAP1188_Library). Use the [CAP1188](/modules/CAP1188.js) ([About Modules](/Modules)) module for it.
+
+You can wire this up as follows:
+
+| Device Pin | Espruino |
+| ---------- | -------- |
+| 1 (GND)    | GND      |
+| 2 (VIN)    | 3.3      |
+| 3 (SDA)    | B7       |
+| 4 (SCK)    | B6       |
+
+Basic usage:
+
+```
+I2C1.setup({scl:B6,sda:B7});
+var cap = require("CAP1188").connect(I2C1);
+cap.readTouches();
+// Returns an array of 8 items for pins C1 - C8
+//  true indicates a touch, false is no touch
+```
+
+Buying
+-----
+
+* [Adafruit](https://www.adafruit.com/products/1602)


### PR DESCRIPTION
This is a port of the Adafruit CAP1188 breakout board Arduino library.

I've kept it simple, this module just allows the 8 touch channels to be read. However, the CAP1188 itself can do a lot more so there's scope to add more functionality later.

I've tested this on an Espruino v1.3b board and the Pico (both with 1v78 firmware).