### PR TITLE
Add TCS3472x module

### DIFF
--- a/devices/TCS3472x.js
+++ b/devices/TCS3472x.js
@@ -1,0 +1,72 @@
+  /* Copyright (C) 2015 Spence Konde. See the file LICENSE for copying permission. */
+  /*
+This module interfaces with the Teos TCS3472x-series light color sensors (the units in this series vary only in I2C address and bus voltage). This module will also work with the 3471x-series, however, the proximity sensing functionality is not supported. This module does not (yet) support power saving features, or the enabling of interrupts.
+
+Usage: 
+
+Setup I2C, then call:
+
+var tcs=require("TCS3472x").connect(I2C1)
+
+Available functions are:
+
+tcs.setGain(gain)
+
+Sets the gain. gain is 1, 4, 16, or 60. 
+
+tcs.setTime(int_cycles)
+
+Sets the number of integration cycles to use, from 1 to 256, 2.4ms per cycle. More integration cycles gives a more accurate result, particularly in low-light conditions, and smooths out noise, but will also miss brief events.
+
+tcs.getValue(); 
+
+returns an object with properties clear, red, green, and blue, corresponding to the values measured by the color sensor. If the status register reports that there is not valid data available, all 4 values are returned as -1 to signify this error condition to the user.
+
+
+*/
+
+
+exports.connect = function(i2c,int_cycles,gain) {
+    return new TCS3472x(i2c,int_cycles,gain);
+};
+
+function TCS3472x(i2c,int_cycles,gain) {
+  this.i2c = i2c;
+  if (int_cycles!==undefined) {
+  	this.setTime(int_cycles);
+  }
+  if (gain!==undefined) {
+  	this.setGain(gain);
+  }
+  this.i2c.writeTo(0x29,0xA0,3);
+}
+
+
+TCS3472x.prototype.setGain= function(gain) {
+	if (gain==1||gain==4||gain==16||gain==60) {
+		var g=(gain==1?0:(gain==4?1:(gain==16?2:3)));
+		this.i2c.writeTo(0x29,0xAF,g);
+	} else {
+		throw "Invalid gain";
+	}
+};
+
+TCS3472x.prototype.setTime= function(cycles) {
+	var g=(256-E.clip(cycles,1,256));
+	this.i2c.writeTo(0x29,0xA1,g);
+};
+
+TCS3472x.prototype.getValue= function() {
+	this.i2c.writeTo(0x29,0xB3);
+	var dat=this.i2c.readFrom(0x29,9);
+	if (dat[0]|1) {
+		var rval={};
+		rval.clear=dat[1]+dat[2]<<8
+		rval.red=dat[3]+dat[4]<<8
+		rval.green=dat[5]+dat[6]<<8
+		rval.blue=dat[7]+dat[8]<<8
+		return rval;
+	} else {
+		return {"clear":-1,"red":-1,"green":-1,"blue":-1};
+	}
+};

--- a/devices/TCS3472x.md
+++ b/devices/TCS3472x.md
@@ -1,0 +1,58 @@
+<!--- Copyright (c) 2015 Spence Konde. See the file LICENSE for copying permission. -->
+TCS3472x I2C Color Sensor
+========================
+
+* KEYWORDS: Module,TCS3472,TCS3471,TCS34725,TCS34721,TCS34723,TCS34727,light,luminosity,visible,color
+
+
+Overview
+------------------
+
+
+
+
+Wiring
+-------------------
+
+The TCS34725 can be purchased as a module, for example from Adafruit. In this case, simply connect Vcc, Gnd, SDA, and SCL to the corresponding pins on the Espruino. Many of these modules also feature a white LED which can be used to illuminate the object being viewed by the color sensor; this may or may not be a useful feature.
+
+If using the bare chip, you will meed an appropriate breakout board for a DFN-6 package, with extended pads so that you can solder to it (unless you're using a reflow oven to solder it). A 0.1uf cap should be used for bypassing - a 0603 cap is the right length that it can be placed right across the Vcc and Gnd pads, provided they're large enough. Soldering the DFN-6 part is tricky, but using the drag soldering technique and some flux, it can be done by hand. If there are not already pullup resistors on the I2C bus (for example, from other connected modules), a 10k pullup resistor must be included from SCL and SDA to Vcc.
+
+Setup
+-------------------
+
+Setup I2C, then call:
+
+```JavaScript 
+var tcs=require("TCS3472x").connect(i2c, integration_cycles, gain)
+```
+
+`i2c` is the i2c bus. 
+
+`integration_cycles` is number of integration cycles to use for each reading 1 to 256. Each cycle takes 2.4ms, and the output of the ADC from each cycle are summed, so the values can be up to 1024*integration_cycles. This means that values of higher than 64 will result in data being clipped at the high end. Using more integration cycles results in more stable readings and reduces the impact of noise, at the cost of making the sensing less responsive to rapid changes and brief events.
+
+`gain` sets the gain of the sensor, for use in low light conditions. Valid options are 1, 4, 16, or 64. 
+
+
+
+-------------------
+
+These support the same interface as the SPI (AT25) and OneWire EEPROM modules
+
+```JavaScript
+tcs.getValue()
+```
+
+Returns an object with properties `clear`, `red`, `green`, and `blue`. These are all numbers from 0-0xFFFF on a successful read, or -1 if the chip reports that no data was ready to read for whatever reason. 
+
+```JavaScript
+tcs.setGain(gain)
+```
+
+Sets the gain - `gain` must be 1, 4, 16, or 60 - no other values of gain are supported.
+
+```JavaScript
+tcs.setTime(integration_cycles)
+```
+
+Sets the number of integration cycles to use, from 1 to 256. 


### PR DESCRIPTION
Works with the TCS3472x color sensors from Teos optoelectronics.