### PR TITLE
Add reset method to CAP1188 module

### DIFF
--- a/devices/CAP1188.md
+++ b/devices/CAP1188.md
@@ -25,6 +25,15 @@ cap.readTouches();
 //  true indicates a touch, false is no touch
 ```
 
+Optionally, you can connect the reset pin on the board (marked RST), to a pin on the Espruino. Call the `reset()` method to reinitialize the sensor. An optional callback can be supplied that's called when the board has been reset.
+
+```
+var cap = require("CAP1188").connect(I2C1, { resetPin: B15 });
+cap.reset(function () {
+  // the board has been reset
+});
+```
+
 Buying
 -----
 


### PR DESCRIPTION
This enables use of the reset pin on the CAP1188 breakout.