### PR TITLE
Modification on BME280 module's instruction.

### DIFF
--- a/devices/BME280.md
+++ b/devices/BME280.md
@@ -17,6 +17,9 @@ You can wire this up as follows:
 | 8 (VCore)  | 3.3          |
 | 3 (SDI)    | B9(I2C1 SDA) |
 | 4 (SCK)    | B8(I2C1 SCL) |
+| 2(CSB)   | 3.3|
+| 5(SDO)  | GND|
+| 6(Vio)   | 3.3|
 
 Don't forget to pull-up both of the I2C pins with 10k resistors.
 


### PR DESCRIPTION
I slightly modified instruction of BME280 module.

- When you use I2C, you have to connect CSB pin to 3.3V.
- The module uses default I2C address (0x76), so you have to connect
SDO pin to GND.
