### PR TITLE
fixing gain (in conversion and constructor

### DIFF
--- a/devices/ADS1X15.js
+++ b/devices/ADS1X15.js
@@ -89,7 +89,7 @@ var REG = {
 function ADS1X15(i2c) {
   this.i2c = i2c;
   this.addr = 0x48;
-  this.gain = 0;
+  this.gain = 2048;
 }
 // used internally for writing to the ADC
 ADS1X15.prototype.writeRegister = function(reg, value) {
@@ -120,7 +120,7 @@ ADS1X15.prototype.getADC = function(channel, callback) {
                     CONFIG.DR_1600SPS   | // 1600 samples per second (default)
                     CONFIG.MODE_SINGLE;   // Single-shot mode (default)
   // Set PGA/voltage range
-  config |= this.gain;
+  config |= GAINS[this.gain];
   // Set single-ended input channel
   config |= [CONFIG.MUX_SINGLE_0,CONFIG.MUX_SINGLE_1,CONFIG.MUX_SINGLE_2,CONFIG.MUX_SINGLE_3][channel];
   // Set 'start single-conversion' bit


### PR DESCRIPTION
To set gain in register on convert, use ‘value’ (from ‘table’ object GAINS) and not just the ‘pointer’ (this.gain).
