### PR TITLE
Fixing ws issue that didn't appear till it was delivered

### DIFF
--- a/modules/ws.js
+++ b/modules/ws.js
@@ -14,7 +14,7 @@
  ```javascript
  // Connect to WiFi, then...
  var WebSocket = require("ws");
- var ws = new WebSocket("HOST",{
+ var ws = WebSocket.init("HOST",{
       port: 8080,
       protocolVersion: 13,
       origin: 'Espruino',
@@ -155,7 +155,7 @@ WebSocket.prototype.join = function (room) {
     this.send(newMsg);
 };
 
-exports = function (host, options) {
+exports.init = function (host, options) {
     var ws = new WebSocket(host, options);
     ws.initializeConnection();
     return ws;

--- a/modules/ws.md
+++ b/modules/ws.md
@@ -25,7 +25,7 @@ To use the [[ws.js]] module (assuming you are already connected to WiFi/Ethernet
 ```js
 var host = "192.168.0.10";
 var WebSocket = require("ws");
-    var ws = new WebSocket(host,{
+    var ws = WebSocket.init(host,{
       port: 8080,
       protocolVersion: 13,
       origin: 'Espruino',


### PR DESCRIPTION
I can't call new Websocket directly without including a function, while it was working fine while testing using var exports = {};
need to discuss it more with Gordon