### PR TITLE
Encoder module: Pins will be checks during initialization and module state will be calculated correctly.

### DIFF
--- a/devices/Encoder.js
+++ b/devices/Encoder.js
@@ -13,7 +13,6 @@ require("Encoder").connect(A1,A2,function (direction) {
 */
 
 function Encoder(/*=PIN*/pina, /*=PIN*/pinb, callback) {
-  this.last = 0;
   this.PINA = pina;
   this.PINB = pinb;
   this.callback = callback;
@@ -33,6 +32,7 @@ function Encoder(/*=PIN*/pina, /*=PIN*/pinb, callback) {
   };
   pinMode(this.PINA, "input_pulldown");
   pinMode(this.PINB, "input_pulldown");
+  onChange(); // initialize the state of a, b and state: no callback will occur
   setWatch(onChange, this.PINA, { repeat: true });
   setWatch(onChange, this.PINB, { repeat: true });
 }


### PR DESCRIPTION
The encoder module did not check the states of the two input pins. this.last was set to 0 while PINA and PINB could be 1.
This leads to the strange behavior that the first rotary movement could result in +1/-1 while the following movement will result in +2/-2.

This pull request uses the available onChange() method to initialize the state of the module without changing any other behavior.