### PR TITLE
Add ST-Link Utility step; erase before program

### DIFF
--- a/boards/Other Boards.md
+++ b/boards/Other Boards.md
@@ -121,6 +121,8 @@ See the [Download](/Download) page for more information - the Web IDE directly s
 
 *   Run the 'STM32 ST-LINK Utility'
 
+*   Click 'Target'->'Erase Chip'
+
 *   Click 'File'->'Open File' and choose espruino_1vXX_stm32vldiscovery.bin
 
 *   When asked if you want to program, click 'Yes'


### PR DESCRIPTION
A few times I've had the weird issue that the Espruino stops connecting to USB. It ceased when I started erasing before programming. 

Is there somewhere else I should add this tidbit? I did try and search google with some terms using `site:espruino.com` but this is the only mention of ST-Link Utility  that I could find.