### PR TITLE
Support of all HTU21D sensor features

### DIFF
--- a/devices/HTU21D.js
+++ b/devices/HTU21D.js
@@ -1,78 +1,325 @@
-/* Copyright (c) 2014 Tom Gidden. See the file LICENSE for copying permission. */
-/*
- * Espruino HTU21D humidity and temperature sensor
- *
- * Derived largely from C++ Arduino HTU21D code, from:
- *   https://github.com/sparkfun/HTU21D_Breakout
- *   by: Nathan Seidle, SparkFun Electronics
- *
- *   Currently unimplemented:
- *   -  HOLD mode
- *   -  User register
- *   -  CRC check
- *
- *   Not currently working right:
- *   -  Reading humidity and temperature at the same time causes I2C timing issues.
- *
+/* Copyright (c) 2014 Tom Gidden, 2015 Luwar. See the file LICENSE for copying permission. */
+
+/**
+ * HTU21D humidity and temperature sensor from Measurement Specialties
  */
+var HTU21D = (function () {
 
-function HTU21D(_i2c, _address) {
-    this.i2c = _i2c;
+    /**
+     * Creates a new HTU21D sensor instance
+     * @param i2c Instance of the I2C Class, e.g. I2C1
+     */
+    function HTU21D( i2c ) {
+        this.i2c = i2c;
 
-    if (address)
-        this.address = _address;
-    else
-        this.address = 0x40;
-}
+        // Possible resolutions
+        this.RH_12_BITS_TEMP_14_BITS = 0x0; // Default after reset
+        this.RH_8_BITS_TEMP_12_BITS = 0x1;
+        this.RH_10_BITS_TEMP_13_BITS = 0x2;
+        this.RH_11_BITS_TEMP_11_BITS = 0x3;
 
-HTU21D.prototype.getTemperature = function(cb) {
-    var self = this;
+        this.i2cAddress = 0x40;
 
-    if(self._tto) {
-        console.log("HTU21D COLLISION");
-        setTimeout(function () { cb(null); }, 0);
-        self._tto = false;
-        return self;
+        // ID of the measuring timer, if asynchronous measuring  with getTemperature() or getHumidity()) is in progress.
+        // null, if there is no current asynchronous meauring
+        this.measuringTimerId = null;
+
+        this.softReset(); // Soft reset is recommended at start according to the datasheet.
     }
 
-    self._tto = true;
+    /**
+     * returns if an asynchronous measuring triggered by getHumidity() or getTemperature() is in progress
+     * @returns {boolean}
+     */
+    HTU21D.prototype.isMeasuring = function () {
+        return !!this.measuringTimerId;
+    };
 
-    self.i2c.writeTo(self.address, [0xf3]);
+    //------------------------------------------------------------------------------------------------------------------
+    // Read Temperature (synchonous / asynchonous)
+    //------------------------------------------------------------------------------------------------------------------
 
-    self._tto = setTimeout(function () {
-        self._tto = false;
-        var d = self.i2c.readFrom(self.address, 3);
-        var raw = ((d[0]<<8) | d[1]) & 0xfffc;
-        cb(-46.85 + (175.72 * raw / 65536));
-    }, 100);
+    /**
+     * Read the temperature in °C from the sensor
+     * This synchronous operation blocks the i2c bus until the measurement is completed.-It takes
+     * at most 50 ms with with 14 bits resolution.
+     * @returns {number}
+     */
+    HTU21D.prototype.readTemperature = function () {
+        this.verifyNotMeasuring();
+        this.writeCommand( HTU21D.CMD_TEMPERATURE_MEASUREMENT_HOLD_MASTER );
+        return -46.85 + 175.72 * this.readMeasuredData() / 65536;
+    };
 
-    return self;
-};
+    /**
+     * Starts an asynchronous temperature measuring
+     * Until the measuring is completed no other command can be send to the sensor!
+     * @param callback function( temperature: number ) { ..} will be called with the temperature result
+     */
+    HTU21D.prototype.getTemperature = function ( callback ) {
+        var _this = this;
+        this.verifyNotMeasuring();
+        // Measure time depends on the configured resolution.
+        var waitMillis = HTU21D.mapResolution2TemperatureMeasurementTime[this.getResolution()];
+        this.writeCommand( HTU21D.CMD_TEMPERATURE_MEASUREMENT_NO_HOLD_MASTER );
+        this.measuringTimerId = setTimeout( function () {
+            _this.measuringTimerId = null;
+            callback( -46.85 + (175.72 * _this.readMeasuredData() / 65536) );
+        }, waitMillis );
+    };
 
-HTU21D.prototype.getHumidity = function(cb) {
-    var self = this;
+    //------------------------------------------------------------------------------------------------------------------
+    // Read Humidity (synchonous / asynchonous)
+    //------------------------------------------------------------------------------------------------------------------
 
-    if(self._hto) {
-        console.log("HTU21D COLLISION");
-        setTimeout(function () { cb(null); }, 0);
-        self._hto = false;
-        return self;
-    }
+    /**
+     * Read the relative humidity in % from the sensor
+     * This synchronous operation blocks the i2c bus until the measurement is completed. It takes at most 16 ms with 12 bits resolution.
+     * @returns {number}
+     */
+    HTU21D.prototype.readHumidity = function () {
+        this.verifyNotMeasuring();
+        this.writeCommand( HTU21D.CMD_HUMIDITY_MEASUREMENT_HOLD_MASTER );
+        return -6 + 125 * this.readMeasuredData() / 65536;
+    };
 
-    self._hto = true;
+    /**
+     * Starts an asynchronous humidity measuring
+     * Until the measuring is completed no other command can be send to the sensor!
+     * @param callback function( humidity: number ) {..} will be called with the humidity result
+     */
+    HTU21D.prototype.getHumidity = function ( callback ) {
+        var _this = this;
+        this.verifyNotMeasuring();
+        // Measure time depends on the configured resolution.
+        var waitMillis = HTU21D.mapResolution2HumidityrMeasurementTime[this.getResolution()];
+        this.writeCommand( HTU21D.CMD_HUMIDITY_MEASUREMENT_NO_HOLD_MASTER );
+        this.measuringTimerId = setTimeout( function () {
+            _this.measuringTimerId = null;
+            callback( -6 + (125 * _this.readMeasuredData() / 65536) );
+        }, waitMillis );
+    };
 
-    self.i2c.writeTo(self.address, [0xf5]);
+    /**
+     * Calculates the temperature compensated humidity
+     * The temperature measured with getHumidity() and readHumidity() is a little bit temperature dependent. With
+     * getCompensatedHumidity() it is possible to reduce/compensate the dependency and get a more accurate value.
+     * @param humidity Measured sensor value get from getHumidity() or readHumidity()
+     * @param temperature Current Temperature from getTemperature() or readTemperature() or any other sensor
+     * @returns {number} Humidity in %
+     */
+    HTU21D.prototype.getCompensatedHumidity = function ( humidity, temperature ) {
+        return humidity + (25 - temperature) * -0.15;
+    };
 
-    self._hto = setTimeout(function () {
-        self._hto = false;
-        var d = self.i2c.readFrom(self.address, 3);
-        var raw = ((d[0]<<8) | d[1]) & 0xfffc;
-        cb(-6 + (125 * raw / 65536));
-    }, 100);
+    /**
+     * Calculate the dew point in dependency on the temperature and the humidity.
+     * The dew point is the temperature at which the water vapor in the air becomes saturated (RH = 100%) and condensation begins.
+     * @param temperature Temperature in °C
+     * @param relativeHumidity Relative Humidity in %
+     * @returns {number} Dew point in °C
+     */
+    HTU21D.prototype.getDewPoint = function ( temperature, relativeHumidity ) {
+        var C = 235.66; // Constant from the datasheet
+        return 1 / (1 / (temperature + C) + (2 - Math.log( relativeHumidity ) / Math.LN10) / 1762.39) - C;
+    };
 
-    return self;
-};
+    /**
+     * softReset() reboots the sensor by switching the power off and on again.
+     * The soft reset takes less than 15ms. The resolution will be set to the highest resolution (RH_12_BITS_TEMP_14_BITS).
+     * The internal heater will be turned off.
+     */
+    HTU21D.prototype.softReset = function () {
+        this.verifyNotMeasuring();
+        this.writeCommand( HTU21D.CMD_SOFT_RESET ); // Sensor will be ready after 15 ms.
+    };
 
-exports.connect = function (_i2c) {
-    return new HTU21D(_i2c);
+    //------------------------------------------------------------------------------------------------------------------
+    // Resolution
+    //------------------------------------------------------------------------------------------------------------------
+
+    /**
+     * read the current configured sensor resolution
+     * @returns {number} Possible return values are:
+     *   0 = RH_12_BITS_TEMP_14_BITS .. humidity: 12 bits resolution, temperature: 14 bits resolution
+     *   1 = RH_8_BITS_TEMP_12_BITS  .. humidity:  8 bits resolution, temperature: 12 bits resolution
+     *   2 = RH_10_BITS_TEMP_13_BITS .. humidity: 10 bits resolution, temperature: 13 bits resolution
+     *   3 = RH_11_BITS_TEMP_11_BITS .. humidity: 11 bits resolution, temperature: 11 bits resolution
+     */
+    HTU21D.prototype.getResolution = function () {
+        this.verifyNotMeasuring();
+        // Move bit 7 to bit 1
+        var reg = this.readUserRegister() & 0x81;
+        return reg & 0x80 ? (reg | 0x2) & 0x3 : (reg & ~0x2) & 0x3;
+    };
+
+    /**
+     * Set a new sensor resolution
+     * The resolution of the temperature and humidity sensor cannot set independently.
+     * @param resolution New sensor resolution. Possible values are documented under getResolution()
+     */
+    HTU21D.prototype.setResolution = function ( resolution ) {
+        this.verifyNotMeasuring();
+        this.writeCommand( HTU21D.CMD_READ_USER_REGISTER );
+        var reg = this.read8();
+        // Move bit 1 to bit 7
+        reg &= ~0x81; // Clear Bit 0 and 7
+        if (resolution & 0x2) {
+            reg |= 0x80;
+        }
+        reg |= (resolution & 0x1);
+        this.i2c.writeTo( this.i2cAddress, [HTU21D.CMD_WRITE_USER_REGISTER, reg] );
+    };
+
+    //------------------------------------------------------------------------------------------------------------------
+    // End of Battery Status
+    //------------------------------------------------------------------------------------------------------------------
+
+    /**
+     * Get the "End of Battery" status
+     * The “End of Battery” alert/status is activated when the battery power falls below 2.25V.
+     * @returns {boolean} true, if the power voltage falls below 2.25V, otherwise false
+     */
+    HTU21D.prototype.isEndOfBattery = function () {
+        this.verifyNotMeasuring();
+        return !!(this.readUserRegister() & 0x40);
+    };
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Heater support
+    //------------------------------------------------------------------------------------------------------------------
+
+    /**
+     * Returns is the internal heater is switched on
+     * @returns {boolean}
+     */
+    HTU21D.prototype.isHeaterOn = function () {
+        this.verifyNotMeasuring();
+        return !!(this.readUserRegister() & 0x04);
+    };
+
+    /**
+     * Change the state of the internal heater.
+     * @param on Status of the heater after this operation. true means "heater on" and false means "heater off".
+     */
+    HTU21D.prototype.setHeaterOn = function ( on ) {
+        this.verifyNotMeasuring();
+        this.writeCommand( HTU21D.CMD_READ_USER_REGISTER );
+        var reg = this.read8();
+        reg = on ? (reg | 0x04) : reg & ~0x04; // set or clear bit 2
+        this.i2c.writeTo( this.i2cAddress, [HTU21D.CMD_WRITE_USER_REGISTER, reg] );
+    };
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Serial Number
+    //------------------------------------------------------------------------------------------------------------------
+
+    /**
+     * Get the unique internal 32 bit serial number of the sensor.
+     * Each HTU21D has an unique serial number which consists of 8 bytes at all. 4 Bytes are common/fixed for all HTU21D sensors.
+     * The other (unique) part will be returned by this operation.
+     * The complete serial number has 64 bit with 4 fixed bytes which will be not returned.
+     * @returns {number} 4 Bytes Unique serial number
+     */
+    HTU21D.prototype.getSerialNumber = function () {
+        this.verifyNotMeasuring();
+        this.i2c.writeTo( this.i2cAddress, [0xfa, 0x0f] );
+        var d = this.i2c.readFrom( this.i2cAddress, 8 );
+        this.i2c.writeTo( this.i2cAddress, [0xfc, 0xc9] );
+        var e = this.i2c.readFrom( this.i2cAddress, 6 );
+        // Check CRC
+        HTU21D.checkCrc( d[0], d[1] );
+        HTU21D.checkCrc( d[2], d[3] );
+        HTU21D.checkCrc( d[4], d[5] );
+        HTU21D.checkCrc( (e[0] << 8) + e[1], e[2] );
+        // Common/Fixed bytes for all HTU21D sensors
+        if (e[3] !== 0x48 || e[4] !== 0x54 || d[0] !== 0x00 || e[0] !== 0x32) {
+            throw new Error( "Invalid Serial Number" );
+        }
+        return (d[2] << 24) | (d[4] << 16) | (d[6] << 8) | e[1];
+    };
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Internal helper methods
+    //------------------------------------------------------------------------------------------------------------------
+
+    // Writes one byte to the i2c sensor
+    HTU21D.prototype.writeCommand = function ( value ) {
+        this.i2c.writeTo( this.i2cAddress, value );
+    };
+
+    // Reads one byte from the i2c sensor
+    HTU21D.prototype.read8 = function () {
+        return this.i2c.readFrom( this.i2cAddress, 1 )[0];
+    };
+
+    // Read the value of the user register
+    HTU21D.prototype.readUserRegister = function () {
+        this.writeCommand( HTU21D.CMD_READ_USER_REGISTER );
+        return this.read8();
+    };
+
+    // Ensures that the sensor is not busy and no asynchonous operation is currently executed
+    // Otherwise an Error exception will be thrown.
+    HTU21D.prototype.verifyNotMeasuring = function () {
+        if (this.measuringTimerId) {
+            throw new Error( "Sensor is measuring." );
+        }
+    };
+
+    HTU21D.prototype.readMeasuredData = function () {
+        var d = this.i2c.readFrom( this.i2cAddress, 3 );
+        var raw = (d[0] << 8) | d[1];
+        HTU21D.checkCrc( raw, d[2] ); // d[2] is the crc value from the sensor.
+        return raw & 0xfffc;
+    };
+
+    /**
+     * CRC with I²C protocol
+     *  - Generator polynomial: x^8 + x^5 + x^4 + 1 → 0x131
+     *  - Initialization      : 0x00
+     *  - Protected data      : Read data (2 Bytes)
+     *  - Final Operation     : none
+     */
+    HTU21D.checkCrc = function ( value, receivedCrc ) {
+        var dividend = value << 8 | receivedCrc; // append crc value
+        var pattern = 1 << 23;
+        for (var i = 0; i < 16; ++i) {
+            if (dividend & pattern) {
+                dividend ^= 0x988000; // = 0x131 << 15, so that x^8 corresponds to the MSB of dividend
+            }
+            dividend <<= 1;
+        }
+        if (dividend) {
+            throw new Error( "CRC Error" );
+        }
+    };
+
+    /*
+     * Possible Values are:
+     * Bit 7    Bit 0    RH         Measuring Time  Temperature Measuring Time
+     * 0        0        12 bits    max. 16 ms      14 bits     50 ms
+     * 0        1         8 bits    max.  3 ms      12 bits     13 ms
+     * 1        0        10 bits    max.  5 ms      13 bits     25 ms
+     * 1        1        11 bits    max.  8 ms      11 bits      7 ms
+     */
+
+    // Mapping between the resolution and the required measuring time in milliseconds
+    HTU21D.mapResolution2TemperatureMeasurementTime = [50, 13, 25, 7];
+    HTU21D.mapResolution2HumidityrMeasurementTime = [16, 3, 5, 8];
+
+    // Internal Sensor Commands
+    HTU21D.CMD_TEMPERATURE_MEASUREMENT_HOLD_MASTER = 0xe3;
+    HTU21D.CMD_HUMIDITY_MEASUREMENT_HOLD_MASTER = 0xe5;
+    HTU21D.CMD_TEMPERATURE_MEASUREMENT_NO_HOLD_MASTER = 0xF3;
+    HTU21D.CMD_HUMIDITY_MEASUREMENT_NO_HOLD_MASTER = 0xf5;
+    HTU21D.CMD_WRITE_USER_REGISTER = 0xe6;
+    HTU21D.CMD_READ_USER_REGISTER = 0xe7;
+    HTU21D.CMD_SOFT_RESET = 0xfe;
+
+    return HTU21D;
+})();
+
+exports.connect = function ( i2c ) {
+    return new HTU21D( i2c );
 };

--- a/devices/HTU21D.md
+++ b/devices/HTU21D.md
@@ -1,6 +1,6 @@
-<!--- Copyright (c) 2014 Tom Gidden. See the file LICENSE for copying permission. -->
+<!--- Copyright (c) 2014 Tom Gidden, 2015 Luwar. See the file LICENSE for copying permission. -->
 HTU21D Temperature and RH Sensor
-=====================
+================================
 
 * KEYWORDS: Module,I2C,HTU21D,temperature,humidity
 
@@ -15,35 +15,154 @@ You can wire this up as follows:
 | SCL        | B6       |
 | SDA        | B7       |
 
-**Note:** On Adafruit's board, don't connect the 3.3v line and instead connect VCC on thb breakout board to Espruino's 3.3v [as discussed here](https://learn.adafruit.com/adafruit-htu21d-f-temperature-humidity-sensor/wiring-and-test)
+**Note:**
+- On Adafruit's board, don't connect the 3.3v line and instead connect VCC on the breakout board to Espruino's 3.3v → https://learn.adafruit.com/adafruit-htu21d-f-temperature-humidity-sensor/wiring-and-test
+- On some Sparkfun's board, the pull up resistors are not connected by default. You need to bridge the solder jumper on the board → https://learn.sparkfun.com/tutorials/htu21d-humidity-sensor-hookup-guide
 
-Basic usage:
+Use cases
+---------
+
+Read the temperature and humidity and wait until the measurement is completed. This blocks the I2C bus and the cpu for at most 50ms:
 
 ```JavaScript
-  I2C1.setup({sda:B7, scl:B6});
-
-  var htu = require('HTU21D').connect(I2C1);
-
-  // Check the humidity every two seconds
-  setInterval(function () {
-    htu.getHumidity(
-      function (x) { console.log("RH = "+x+"%"); }
-    );
-  }, 2000);
-
-  // Stagger the temperature reading by one second, to prevent conflict
-  setTimeout(function () {
-
-    // Check the temperature every two seconds
-    setInterval(function () {
-      htu.getTemperature(
-        function (x) { console.log("T = "+x+" oC"); }
-      );
-    }, 2000);
-  }, 1000);
+I2C1.setup( {scl: B8, sda: B9 } );
+var htu = require('HTU21D').connect( I2C1 );
+console.log( "Temperature = " + htu.readTemperature() + " °C" );
+console.log( "Humidity    = " + htu.readHumidity() + " %" );
 ```
+
+If you want to work asynchronously then you have to use the getTemperature() and getHumidity().
+
+```JavaScript
+I2C1.setup( {scl: B8, sda: B9 } );
+var htu = require('HTU21D').connect( I2C1 );
+
+var temperature;
+var humidity;
+
+function startMeasuring() {
+  htu.getTemperature( function(temp) {
+    htu.getHumidity( function(hum) {
+      temperature = temp;
+      humidity = hum;
+      startMeasuring(); // start the next measuring cycle
+    });
+  } );
+}
+startMeasuring();
+
+// It's forbidden to call a HTU21D method while measuring asynchronously!
+// e.g. htu.readTemperature() would here throw an exception.
+
+// After 50 ms the temperature and humidity are always up-to-date.
+setInterval( function() {
+  console.log( "T = " + temperature.toFixed(2) + " °C, " +
+               "RH = " + humidity.toFixed(2) + " %" );
+}, 100 );
+```
+
+**Note**
+
+It's important to make sure that the sensor will not be used during an asynchronous measuring.
+This is an incorrect usage:
+```JavaScript
+I2C1.setup( {scl: B8, sda: B9, bitrate: 50000 } );
+var htu = require('HTU21D').connect( I2C1 );
+
+htu.getTemperature( function (temp) { console.log(temp); } );
+
+// This will throw an error "Sensor is measuring" !
+htu.getHumidity( function( humidity ) {
+} );
+```
+
+The humidity is slightly temperature dependent but you can compensate this dependency if you have the current temperature:
+```JavaScript
+I2C1.setup( {scl: B8, sda: B9 } );
+var htu = require('HTU21D').connect( I2C1 );
+var temp = htu.readTemperature();
+var humidity = htu.readHumidity(); 
+humdity = htu.getCompensatedHumidity( humidity, temp ); // improve accuracy
+console.log("Temperature = " + temp.toFixed(2) + " °C" );
+console.log("Humidity    = " + humidity.toFixed(2) + " %" );
+console.log("Dew point   = " + htu.getDewPoint(temp,humidity).toFixed(2) + " °C");
+```
+
+Sometime it is not required to work with the highest resolution. With a lower resolution the
+measuring time is decreasing and so the power consumption:
+
+```JavaScript
+I2C1.setup( {scl: B8, sda: B9 } );
+var htu = require('HTU21D').connect( I2C1 );
+
+// 12 instead of 14 bits but only 13 ms instead of 50 ms
+htu.setResolution( htu.RH_8_BITS_TEMP_12_BITS );
+
+// This call takes only 13 ms instead of 50 ms.
+var temperature = htu.readTemperature();
+console.log( "T = " + temperature );
+```
+
+Possible resolutions are:
+
+|                         | RH      | Measuring Time | Temperature | Measuring Time |
+| ----------------------- | ------- | -------------- | ----------- | -------------- |
+| RH_12_BITS_TEMP_14_BITS | 12 bits | max. 16 ms     | 14 bits     | 50 ms          |
+| RH_8_BITS_TEMP_12_BITS  |  8 bits | max.  3 ms     | 12 bits     | 13 ms          |
+| RH_10_BITS_TEMP_13_BITS | 10 bits | max.  5 ms     | 13 bits     | 25 ms          |
+| RH_11_BITS_TEMP_11_BITS | 11 bits | max.  8 ms     | 11 bits     |  7 ms          |
+
+Every HTU21D sensor has a unique chip identification number. Maybe you wants to tag your delivered devices?  
+
+```JavaScript
+I2C1.setup( {scl: B8, sda: B9 } );
+var htu = require('HTU21D').connect( I2C1 );
+console.log( "0x" + htu.getSerialNumber().toString(16) ); // → e.g. 0x2ee38a18
+```
+
+The internal heater can be used for checking the operation and for preventing condensation:
+
+```JavaScript
+I2C1.setup( {scl: B8, sda: B9 } );
+var htu = require('HTU21D').connect( I2C1 );
+
+console.log( "Heater = " + htu.isHeaterOn() ); // → false
+htu.setHeaterOn( true );
+console.log( "Heater = " + htu.isHeaterOn() ); // → true
+htu.setHeaterOn( false );
+console.log( "Heater = " + htu.isHeaterOn() ); // → false
+```
+
+You can reboot the sensor to initial state (maximal resolution, heater off) with a soft reset:
+
+```JavaScript
+htu.setHeaterOn( true );
+htu.setResolution( htu.RH_8_BITS_TEMP_12_BITS );
+
+htu.softReset();
+
+console.log( "Heater = " + htu.isHeaterOn() ); // → false
+console.log( "max. resolution = " + (htu.getResolution() === htu.RH_8_BITS_TEMP_12_BITS ) );  // → false
+console.log( "max. resolution = " + (htu.getResolution() === htu.RH_12_BITS_TEMP_14_BITS ) ); // → true
+```
+
+The sensor operates from 1.5V to 3.6V. Its possible
+to detect a voltage supply less than 2.25V:
+
+```JavaScript
+console.log( "End of battery = " + htu.isEndOfBattery() ); // → false
+```
+
 
 Buying
 -----
 
 * [AdaFruit breakout board](https://www.adafruit.com/products/1899)
+* [SparkFun Breakout](https://www.sparkfun.com/products/12064)
+* .. or cheaper from EBay
+
+Links
+-----
+* Manufacturer MEAS http://www.meas-spec.com/product/humidity/HTU21D.aspx
+* Datasheet http://www.meas-spec.com/downloads/HTU21D.pdf
+* HTU2X Serial Number Reading http://www.meas-spec.com/downloads/HTU2X_Serial_Number_Reading.pdf


### PR DESCRIPTION
I have completed the HTU21D module to support all sensor features:

- Get and change sensor resolution
- Read temperature in blocking/synchronous mode
- Read humidity in blocking/synchronous mode
- CRC Checks added
- Read chip identification / serial number
- Calculate temperature compensated humidity
- Calculate the dew point
- No "console.log" for standalone operation
- Heater support
- Soft Reset
- Read End of Battery Status

There is no api break. All functions were testet with a real sensor.