### PR TITLE
Fix DHT22 lib for AM2301

### DIFF
--- a/devices/DHT22.js
+++ b/devices/DHT22.js
@@ -37,7 +37,7 @@ DHT22.prototype.read = function (a) {
 DHT22.prototype.onread= function(d) {
     var dht=this;
     if (d.temp==-1) {
-        dht.readfails++
+        dht.readfails++;
         if(dht.readfails < 20) {
             dht.read(dht.onreadf);
         } else {

--- a/devices/DHT22.md
+++ b/devices/DHT22.md
@@ -1,5 +1,5 @@
 <!--- Copyright (c) 2014 Spence Konde. See the file LICENSE for copying permission. -->
-DHT22/AM2302 Temperature and RH Sensor
+DHT22/AM2302/AM2301 Temperature and RH Sensor
 =====================
 
 * KEYWORDS: Module,DHT22,AM2302,temperature,humidity
@@ -7,7 +7,7 @@ DHT22/AM2302 Temperature and RH Sensor
 Overview
 -----------------
 
-This module interfaces with the DHT22 (AKA AM2302), an inexpensive temperature and relative humidity sensor similar to the DHT11, but with higher accuracy and wider range. 
+This module interfaces with the DHT22 (AKA AM2302, AM2301), an inexpensive temperature and relative humidity sensor similar to the DHT11, but with higher accuracy and wider range. 
 
 Key Specifications:
 
@@ -39,13 +39,18 @@ IMPORTANT: Be sure to get the polarity right! If connected backwards, it will ru
 Usage
 ------------
 
-call require("DHT22").connect(pin) to get a DHT22 object. To read the sensor, the read method is called with a single argument, the function that is called when the read is complete. This function is called with an object containing two properties, temp and rh. Temperature is in C, RH is in %. 
+Call `require("DHT22").connect(pin)` to get a DHT22 object. To read the sensor, the read method is called with a single argument, the function that is called when the read is complete. This function is called with an object containing two properties, `temp` and `rh`. Temperature is in °C, RH is in %. 
 
 For example:
 ```JavaScript
     var dht = require("DHT22").connect(C11);
     dht.read(function (a) {console.log("Temp is "+a.temp.toString()+" and RH is "+a.rh.toString());});
 ```
+Returns -1 for the temperature and humidity if no data is received. An extra `checksumError` field contains extra information about the type of the failure:
+
+The return value if no data received at all: `{"temp": -1, "rh": -1, "checksumError": false}`.
+
+The return value, if some data received, but the checksum is invalid, or timed out: `{"temp": -1, "rh": -1, "checksumError": true}`
 
 Buying
 -----


### PR DESCRIPTION
@gfwilliams I only have an ESP8266 board, so can't verify it on a real espruino and to test the issue you would need a AM2301. I hope i can explain this properly...
The problem: AM2301 is supposed to be compatible with DHT22, but (at least the one I got) transmits some "0" bytes after the real payload. 
An annoted screenshot from logic analyzer showing DHT22 and AM2301: https://files.gitter.im/espruino/Espruino/9vqG/blob
@SpenceKonde 's code didn't terminate after all the expected data received, and since additional bits received from the AM2301, that caused the checksum bit to be shifted (the exact number of additional shifts depends on timing, the code waits for 50 ms).
So modified the code to terminate after 40 bits received (of course, left the 50ms timeout in it).

Checked on EPS8266 with DHT22 and AM2301 side by side. The code still correctly handles if no sensor is plugged in.

@SpenceKonde please take a look at this, since you wrote the original. I have non-image exports from the logic analyzer those captures...