### PR TITLE
lora.LoRaWAN() method used to configure the LoRaWAN keys (DevAddr, nw…

### DIFF
--- a/devices/RN2483.js
+++ b/devices/RN2483.js
@@ -105,6 +105,29 @@ RN2483.prototype.getStatus = function(callback) {
   });
 };
 
+/// configure the LoRaWAN parameters
+RN2483.prototype.LoRaWAN = function(devAddr,nwkSKey,appSKey, callback)
+{
+  var at = this.at;
+  (new Promise(function(resolve) {
+    at.cmd("mac set devaddr "+devAddr+"\r\n",500,resolve);
+  })).then(function(d) {
+    return new Promise(function(resolve) {
+      at.cmd("mac set nwkskey "+nwkSKey+"\r\n",500,resolve);
+    });
+  }).then(function(d) {
+    return new Promise(function(resolve) {
+      at.cmd("mac set appskey "+appSKey+"\r\n",500,resolve);
+    });
+  }).then(function(d) {
+    return new Promise(function(resolve) {
+      at.cmd("mac join ABP\r\n",2000,resolve);
+    });
+  }).then(function(d) {
+    callback(d);
+  });
+};
+
 /// Set whether the MAC (LoRaWan) is enabled or disabled
 RN2483.prototype.setMAC = function(on, callback) {
   if (this.macOn==on) return callback();


### PR DESCRIPTION
This PR adds a function to configure the LoRaWAN settings. You just have to give 3 parameters :
- DevAddr
- nwkSKey
- appSKey

Further information, see [here](https://www.thethingsnetwork.org/wiki/LoRaWAN/Security)

Usage:
```javascript
lora.LoRaWAN(devAddr,nwkSKey,appSKey,function(x){console.log(x);});
lora.loraTX("Hello");
```

This have been tested with Espruino 1v87.852 on a Pico