### PR TITLE
Use HTTPS for embedded video

### DIFF
--- a/puck/Puck.js Infrared.md
+++ b/puck/Puck.js Infrared.md
@@ -7,7 +7,7 @@ Infrared Record and Playback with Puck.js
 
 This video shows you how to control Infrared devices using Puck.js.
 
-[[http://youtu.be/et58ozE-Cu8]]
+[[https://youtu.be/et58ozE-Cu8]]
 
 You'll need a [Puck.js](/Puck.js) and an (Infrared Receiver)[/IRReceiver]
 


### PR DESCRIPTION
Currently the video doesn't show up in Chrome/Linux as it says it's not secure.

There are probably others that need changing to, but this is the only one I've seen.