### PR TITLE
Docs

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -344,6 +344,7 @@ function inferMarkdownFile(filename, fileContents) {
 // -------------------------------------------------------------
 markdownFiles.forEach(function (file) {
    var contents = preloadedFiles[file] ? preloadedFiles[file] : fs.readFileSync(file).toString();
+   console.log(file);
    //console.log(file,contents.length);
    // Check over images... ![Image Title](foo.png)
    contents = handleImages(file, contents);
@@ -411,9 +412,9 @@ markdownFiles.forEach(function (file) {
      var match;
      match = contentLines[i].match(/^\* APPEND_JSDOC: (.*)/);
      if (match!=null) {
+       console.log("APPEND_JSDOC "+jsfilename);
        var jsfilename = file.substr(0, file.lastIndexOf("/")+1) + match[1];
        var js = fs.readFileSync(jsfilename).toString();
-       console.log("APPEND_JSDOC "+jsfilename);
        var doc = common.getJSDocumentation(js);
        /* setting the language to Java lets it be highlighted correctly
        while not adding the 'send to Espruino' icon */

--- a/boards/WiFi.md
+++ b/boards/WiFi.md
@@ -104,7 +104,7 @@ function onInit() {
 Espruino WiFi's module is designed to work similarly to the [ESP8266 native WiFi module](http://www.espruino.com/Reference#Wifi),
 however *you can't use the `WiFi` module directly*. Eventually you will, however this is still in development.
 
-* APPEND_JSDOC: ../devices/EspruinoWiFi.js
+* APPEND_JSDOC: devices/EspruinoWiFi.js
 
 
 Tutorials


### PR DESCRIPTION
got rid of another problem
still getting there
---

```
$ ./build.sh
Script location C:\Users\owen\source\repos\github\OwenBrotherwood\Espruino\scripts
BOARD PICO_R1_3
HTML_FILENAME boards/PICO_R1_3.html
cp: cannot create regular file '/c/Users/owen/workspace/espruinowebsite/www/img': No such file or directory
Script location C:\Users\owen\source\repos\github\OwenBrotherwood\Espruino\scripts
BOARD ESPRUINOBOARD
HTML_FILENAME boards/ESPRUINOBOARD.html
cp: cannot stat 'boards/img/ESPRUINOBOARD.png': No such file or directory
Script location C:\Users\owen\source\repos\github\OwenBrotherwood\Espruino\scripts
BOARD ESP8266_BOARD
HTML_FILENAME boards/ESP8266_BOARD.html
cp: cannot stat 'boards/img/ESP8266_BOARD.png': No such file or directory
Script location C:\Users\owen\source\repos\github\OwenBrotherwood\Espruino\scripts
BOARD EMW3165
HTML_FILENAME boards/EMW3165.html
cp: cannot stat 'boards/img/EMW3165.png': No such file or directory
Script location C:\Users\owen\source\repos\github\OwenBrotherwood\Espruino\scripts
BOARD MICROBIT
HTML_FILENAME boards/MICROBIT.html
cp: cannot create regular file '/c/Users/owen/workspace/espruinowebsite/www/img': No such file or directory
Script location C:\Users\owen\source\repos\github\OwenBrotherwood\Espruino\scripts
BOARD ESPRUINOWIFI
HTML_FILENAME boards/ESPRUINOWIFI.html
cp: cannot create regular file '/c/Users/owen/workspace/espruinowebsite/www/img': No such file or directory
Script location C:\Users\owen\source\repos\github\OwenBrotherwood\Espruino\scripts
BOARD PUCKJS
HTML_FILENAME boards/PUCKJS.html
cp: cannot create regular file '/c/Users/owen/workspace/espruinowebsite/www/img': No such file or directory
Example File examples\distance_sensing_robot.js
Example File examples\http_file_server.js
Example File examples\http_get_image.js
Example File examples\led_vu_meter.js
Example File examples\rgb123_reaction_timer.js
Example File examples\simple_data_logger.js
Example File examples\slideshow_ili9341.js
Example File examples\temperature_display_pcd8544.js
Example File examples\temperature_graph_pcd8544.js
Example File examples\useless_box.js
Example File examples\wifi_humidity.js
Example File examples\wii_remote_control_helicopter.js
Example File examples\ws2811_led_clock.js
APPEND_PINOUT C:\Users\owen\source\repos\github\OwenBrotherwood\EspruinoDocs/html/boards/EMW3165.html
WARNING: boards\EspruinoBoard.md: Image 'boards\EspruinoBoard.md/EspruinoBoard/main.jpg' does not exist
WARNING: boards\EspruinoBoard.md: Image 'boards\EspruinoBoard.md/EspruinoBoard/annotated_1v4.jpg' does not exist
WARNING: boards\EspruinoBoard.md: Image 'boards\EspruinoBoard.md/EspruinoBoard/annotated_1v3.jpg' does not exist
WARNING: boards\EspruinoBoard.md: Image 'boards\EspruinoBoard.md/EspruinoBoard/power.png' does not exist
WARNING: APPEND_USES for 'espruinoboard' in boards\EspruinoBoard.md found nothing
APPEND_PINOUT C:\Users\owen\source\repos\github\OwenBrotherwood\EspruinoDocs/html/boards/ESPRUINOBOARD.html
APPEND_PINOUT C:\Users\owen\source\repos\github\OwenBrotherwood\EspruinoDocs/html/boards/ESP8266_BOARD.html
WARNING: boards\MicroBit.md: Image 'boards\MicroBit.md/MicroBit/board.jpg' does not exist
WARNING: APPEND_USES for 'microbit' in boards\MicroBit.md found nothing
APPEND_PINOUT C:\Users\owen\source\repos\github\OwenBrotherwood\EspruinoDocs/html/boards/MICROBIT.html
WARNING: boards\Pico.md: Image 'boards\Pico.md/Pico/angled.jpg' does not exist
WARNING: boards\Pico.md: Image 'boards\Pico.md/Pico/diagram.png' does not exist
WARNING: boards\Pico.md: Image 'boards\Pico.md/Pico/smd.jpg' does not exist
WARNING: boards\Pico.md: Image 'boards\Pico.md/Pico/footprint.png' does not exist
WARNING: boards\Pico.md: Image 'boards\Pico.md/Pico/jst.jpg' does not exist
WARNING: boards\Pico.md: Image 'boards\Pico.md/Pico/microusb.jpg' does not exist
WARNING: boards\Pico.md: Image 'boards\Pico.md/Pico/power.png' does not exist
APPEND_PINOUT C:\Users\owen\source\repos\github\OwenBrotherwood\EspruinoDocs/html/boards/PICO_R1_3.html
WARNING: boards\Puck.js.md: Image 'boards\Puck.js.md/Puck.js/board.jpg' does not exist
APPEND_PINOUT C:\Users\owen\source\repos\github\OwenBrotherwood\EspruinoDocs/html/boards/PUCKJS.html
WARNING: boards\WiFi.md: Image 'boards\WiFi.md/WiFi/angled.jpg' does not exist
WARNING: APPEND_USES for 'espruinowifi' in boards\WiFi.md found nothing
fs.js:640
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open 'C:\Users\owen\source\repos\github\OwenBrotherwood\devices\EspruinoWiFi.js'
    at Error (native)
    at Object.fs.openSync (fs.js:640:18)
    at Object.fs.readFileSync (fs.js:508:33)
    at C:\Users\owen\source\repos\github\OwenBrotherwood\EspruinoDocs\bin\build.js:415:20
    at Array.forEach (native)
    at Object.<anonymous> (C:\Users\owen\source\repos\github\OwenBrotherwood\EspruinoDocs\bin\build.js:345:15)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)

```