### PR TITLE
EspruinoWifi: bugfix for scan function

### DIFF
--- a/devices/EspruinoWiFi.js
+++ b/devices/EspruinoWiFi.js
@@ -287,15 +287,18 @@ exports.stopAP = function() {
    an array of {ssid, authMode, rssi, mac, channel} */
 exports.scan = function(callback) {
   var aps = [];
+  turnOn(MODE.CLIENT, function(err) {
+    if (err) return callback(err);
     at.cmdReg("AT+CWLAP\r\n", 5000, "+CWLAP:",
-      function(d) { 
-        var ap = d.slice(8,-1).split(","); 
+      function(d) {
+        var ap = d.slice(8,-1).split(",");
         aps.push({ ssid : JSON.parse(ap[1]),
-                   authMode: ENCR_FLAGS[ap[0]],                           
+                   authMode: ENCR_FLAGS[ap[0]],
                    rssi: parseInt(ap[2]),
                    mac : JSON.parse(ap[3]),
-                   channel : JSON.parse(ap[4]) }); 
+                   channel : JSON.parse(ap[4]) });
       },
-      function(d) { callback(null, aps); });
+      function(d) { callback(null, aps); }
+    );
+  });
 };
-


### PR DESCRIPTION
Following code
```
var wifi = require("EspruinoWiFi");

wifi.scan(function() {
  console.log(arguments);
});
```

Results in
```
>Uncaught Error: Field or method "cmdReg" does not already exist, and can't create it on undefined
 at line 1 col 11
var b=[];d.cmdReg("AT+CWLAP\r\n",5E3,"+CWLAP:",function(a){a...
          ^
in function "scan" called from line 3 col 2
});
 ^
=undefined
> 
```

This PR fixes that.