### PR TITLE
Enhance Vizibles documentation

### DIFF
--- a/modules/Vizibles.es.md
+++ b/modules/Vizibles.es.md
@@ -47,8 +47,8 @@ connect = function(options, callback, connectionCb, disconnectionCb)
 `options` es un objeto con pares clave/valor para configurar la conexión 
 ```
 {
-    'keyID': 'Gp2naLrsSpFE',
-    'keySecret' : 'wGyFTwIHvYwGCBDJyA7j',
+    'keyID': 'TU_KEY_ID',
+    'keySecret' : 'TU_KEY_SECRET',
     'id' : 'light-bulb'
 }
 ```

--- a/modules/Vizibles.md
+++ b/modules/Vizibles.md
@@ -47,8 +47,8 @@ connect = function(options, callback, connectionCb, disconnectionCb)
 `options` is an object containing key/value pairs for configuring the connection 
 ```
 {
-    'keyID': 'Gp2naLrsSpFE',
-    'keySecret' : 'wGyFTwIHvYwGCBDJyA7j',
+    'keyID': 'YOUR_KEY_ID',
+    'keySecret' : 'YOUR_KEY_SECRET',
     'id' : 'light-bulb'
 }
 ```


### PR DESCRIPTION
	Changed Key Secret and Key ID on Vizibles module examples to make them abviously wrong, so force averyone to create their own instead of testing generic (wrong) but credible values.