### PR TITLE
Error correction in setMT(mt) function.

### DIFF
--- a/devices/BH1750.js
+++ b/devices/BH1750.js
@@ -81,8 +81,8 @@ BH1750.prototype.start= function(resolution,onetime) { //resolution: 1 = 1 lx (r
 };
 
 BH1750.prototype.setMT=function(mt) {
-  this.factor=1.2/(69/X);
   mt=E.clip(mt,31,254);
+  this.factor=1.2/(69/mt);
   this.i2c.writeTo(this.i2ca,0x80+((mt&0xE0)>>3));
   this.i2c.writeTo(this.i2ca,0xB0+(mt&0x1F));
 }


### PR DESCRIPTION
The function setMT(mt) did not work. The code was copied from the datasheet BH1750, but it is not working: `1 / 1.2 *( 69 / X )`, where `X` is MTreg value.
The variable `X` caused an error in `this.factor=1.2/(69/X)`.