### PR TITLE
VL53 Module, add support for more than one sensor on the same bus

### DIFF
--- a/devices/VL53L0X.js
+++ b/devices/VL53L0X.js
@@ -4,11 +4,19 @@ var C = {
   REG_RESULT_RANGE_STATUS : 0x0014
 };
 
+/** 
+Init VL53 Sensor with default address.
+Store Address in a variable, this allows to change the address later.
+*/
 function VL53L0X(i2c, options) {
   this.options = options||{};
   this.i2c = i2c;
-  //this.r(0xC0,1)[0]==0xEE;
-  // initialise
+  this.ad = 0x52>>1;
+  this.init();
+}
+
+/** initialise VL53L0X */
+VL53L0X.prototype.init = function() {
   this.w(0x80, 0x01);
   this.w(0xFF, 0x01);
   this.w(0x00, 0x00);
@@ -16,14 +24,20 @@ function VL53L0X(i2c, options) {
   this.w(0x00, 0x01);
   this.w(0xFF, 0x00);
   this.w(0x80, 0x00);
-}
+};
+
+/** this function set a new device address.
+Call this function before you initialise the VL53! */
+VL53L0X.prototype.a = function(addr) {
+  this.i2c.writeTo(0x52>>1, 0x8a, addr);
+};
 
 VL53L0X.prototype.r = function(addr,n) {
-  this.i2c.writeTo(0x52>>1, addr);
-  return this.i2c.readFrom(0x52>>1, n);
+  this.i2c.writeTo(this.ad, addr);
+  return this.i2c.readFrom(this.ad, n);
 };
 VL53L0X.prototype.w = function(addr,d) {
-  this.i2c.writeTo(0x52>>1, addr, d);
+  this.i2c.writeTo(this.ad, addr, d);
 };
 
 /** Perform one measurement and return the result.
@@ -61,6 +75,16 @@ VL53L0X.prototype.performSingleMeasurement = function() {
   // TODO: use LinearityCorrectiveGain/etc
   return res;
 };
+
+/** Parameters
+   newAddress -> new I2C Address which should be used for this device
+				 The Address should be a multiple of 2! Please consider
+				 other devices on the bus!
+ */
+VL53L0X.prototype.changeAddress = function( newAddress ) {
+	this.a( newAddress>>1 );
+	this.ad = newAddress>>1;
+}
 
 exports.connect = function(i2c, options) {
   return new VL53L0X(i2c, options);

--- a/devices/VL53L0X.js
+++ b/devices/VL53L0X.js
@@ -5,16 +5,20 @@ var C = {
 };
 
 /** 
-Init VL53 Sensor with default address.
-Store Address in a variable, this allows to change the address later.
+Init VL53 Sensor if no address is provided, default address is used.
+Store Address in a variable which is used for communication.
 */
 function VL53L0X(i2c, options) {
-  this.options = options||{};
-  this.i2c = i2c;
-  this.ad = 0x52>>1;
-  this.init();
+    this.options = options||{};
+    this.i2c = i2c;
+    this.ad = 0x52>>1;
+    if (this.options.address) {
+    // Change I2C address, if specified in options
+     this.ad = this.options.address>>1;
+     this.i2c.writeTo(0x52>>1, 0x8a, this.ad);
+    }
+    this.init();
 }
-
 /** initialise VL53L0X */
 VL53L0X.prototype.init = function() {
   this.w(0x80, 0x01);
@@ -24,12 +28,6 @@ VL53L0X.prototype.init = function() {
   this.w(0x00, 0x01);
   this.w(0xFF, 0x00);
   this.w(0x80, 0x00);
-};
-
-/** this function set a new device address.
-Call this function before you initialise the VL53! */
-VL53L0X.prototype.a = function(addr) {
-  this.i2c.writeTo(0x52>>1, 0x8a, addr);
 };
 
 VL53L0X.prototype.r = function(addr,n) {
@@ -75,16 +73,6 @@ VL53L0X.prototype.performSingleMeasurement = function() {
   // TODO: use LinearityCorrectiveGain/etc
   return res;
 };
-
-/** Parameters
-   newAddress -> new I2C Address which should be used for this device
-				 The Address should be a multiple of 2! Please consider
-				 other devices on the bus!
- */
-VL53L0X.prototype.changeAddress = function( newAddress ) {
-	this.a( newAddress>>1 );
-	this.ad = newAddress>>1;
-}
 
 exports.connect = function(i2c, options) {
   return new VL53L0X(i2c, options);

--- a/devices/VL53L0X.md
+++ b/devices/VL53L0X.md
@@ -112,14 +112,14 @@ Enable Second VL53 Sensor,
 function InitVL53( ) {
   console.log("Init VL53 1");
   digitalWrite(B3,1); // set XSDN -> turn the sensor on
-  laser1 = require("VL53L0X_2").connect(I2C1);
+  laser1 = require("VL53L0X").connect(I2C1);
 
   console.log("Change Address");
   laser1.changeAddress(0x54);  
     
   console.log("Init VL53 2");
   digitalWrite(B5,1); // set XSDN -> turn the sensor on
-  laser2 = require("VL53L0X_2").connect(I2C1);
+  laser2 = require("VL53L0X").connect(I2C1);
 }
 
 function onTimer() {

--- a/devices/VL53L0X.md
+++ b/devices/VL53L0X.md
@@ -12,6 +12,8 @@ The VL53L0X is an amazing laser time of flight range sensor that connects via [[
 
 It'll measure distances up to 2m, accurate to around 5%, and needs between 2.5 and 3.6 volts.
 
+It's possible to use more than one sensor on the same I2C Interface.
+
 Wiring
 ------
 
@@ -69,6 +71,86 @@ Currently there is no calibration performed so the results aren't
 as accurate as they could be. ST don't appear to have documented
 the sensor's interface properly, so to calibrate you would need
 to reverse engineer their libraries.
+
+Using more than one Sensor
+--------
+
+This example shows how to use more than one sensor by calling the changeAddress function. 
+Things you have to considere: This example uses different pins than the example before.
+The table shows how the pins are connected:
+
+| Name | Espruino | VL53 (1) | VL53 (2) |
+|------|----------|-------|-------|
+| SCL  | I2C SCL (B8)   | X | X |
+| SDA  | I2C SDA (B9)   | X | X |
+| XSDN1 | Any GPIO (B3) | X |   |
+| XSDN2 | Any GPIO (B5) |   | X |
+| VDD | 3.3v            | X | X |
+| GND | GND             | X | X |
+
+* **XSDN** should be both conected to different IO pins. 
+  It's not possible to use two sensors if XSDN of one is connected to VDD.
+* **STARTUP** B3 and B5 have to be set to 0 during startup. This will reset the VL53 
+  Sensor. This means: the sensor starts allways with the default address.
+* **TIMING** I2C Communication needs time! A datarate of 400k is supported. 
+  If you combine the VL53 with a slow I2C device this will increase the time to get the sensor data!
+  The slowest device will determine the busspeed!
+* **RESISTORS** I2C needs Pull up resistors. The VL53 Modules from ST don't inlcude pullup-resistors. 
+This means you need one extensionmodule with I2C Pull up resistors or you connect two resistors yourself!
+
+The example below will init two VL53 Sensors and the read the sensors every 200ms. The result is written on the serial interface.
+
+```
+/** global variables */
+var laser1;
+var laser2;
+
+/** 
+Enable first VL53 Sensor, Change Adress
+Enable Second VL53 Sensor, 
+ */
+function InitVL53( ) {
+  console.log("Init VL53 1");
+  digitalWrite(B3,1); // set XSDN -> turn the sensor on
+  laser1 = require("VL53L0X_2").connect(I2C1);
+
+  console.log("Change Address");
+  laser1.changeAddress(0x54);  
+    
+  console.log("Init VL53 2");
+  digitalWrite(B5,1); // set XSDN -> turn the sensor on
+  laser2 = require("VL53L0X_2").connect(I2C1);
+}
+
+function onTimer() {
+  var l1 = laser1.performSingleMeasurement().distance;
+  var l2 = laser2.performSingleMeasurement().distance;
+  console.log("Sensor 1: "+ l1 +" mm, Sensor 2: "+l2+" mm" );
+}
+
+/** 
+Set IO Pins to low for VL53 Sensors (turn off)
+Enable I2C Interface, Set IO Interrupts
+*/
+function InitHW( ) {
+  console.log("Turn off VL53 vSensors");
+  digitalWrite(B3,0); // set XSDN -> turn the sensor off
+  digitalWrite(B5,0); // set XSDN -> turn the sensor off
+  
+  console.log("I2C Interface on, 400k");
+  I2C1.setup({ sda:B9, scl:B8, bitrate:400000} );
+}
+
+function DoStart() {
+  console.log("Init");
+  InitHW();
+  InitVL53();
+  setInterval(onTimer, 200);
+  console.log("Running");
+}
+
+DoStart();
+```
 
 Reference
 ---------

--- a/devices/VL53L0X.md
+++ b/devices/VL53L0X.md
@@ -98,7 +98,7 @@ The table shows how the pins are connected:
 * **RESISTORS** I2C needs Pull up resistors. The VL53 Modules from ST don't inlcude pullup-resistors. 
 This means you need one extensionmodule with I2C Pull up resistors or you connect two resistors yourself!
 
-The example below will init two VL53 Sensors and the read the sensors every 200ms. The result is written on the serial interface.
+The example below will init two VL53 Sensors and the read the sensors every 200ms. Each sensor will get a address which is different from the default address (0x52). The result is written on the serial interface.
 
 ```
 /** global variables */
@@ -112,14 +112,11 @@ Enable Second VL53 Sensor,
 function InitVL53( ) {
   console.log("Init VL53 1");
   digitalWrite(B3,1); // set XSDN -> turn the sensor on
-  laser1 = require("VL53L0X").connect(I2C1);
+  laser1 = require("VL53L0X").connect(I2C1, {address:0x54 });
 
-  console.log("Change Address");
-  laser1.changeAddress(0x54);  
-    
   console.log("Init VL53 2");
   digitalWrite(B5,1); // set XSDN -> turn the sensor on
-  laser2 = require("VL53L0X").connect(I2C1);
+  laser2 = require("VL53L0X").connect(I2C1, {address:0x56 });
 }
 
 function onTimer() {


### PR DESCRIPTION
This change will add support for the changeAddress feature of the VL53. By using this feature it's possible to use more than one sensor on the same I2C bus.