### PR TITLE
Added a first reference to the inline c compiler

### DIFF
--- a/bin/espruino.json
+++ b/bin/espruino.json
@@ -1025,6 +1025,11 @@
       "!doc": "<p>Provide assembly to Espruino.</p>\n<p><strong>This function is not part of Espruino</strong>. Instead, it is detected\nby the Espruino IDE (or command-line tools) at upload time and is\nreplaced with machine code and an <code>E.nativeCall</code> call.</p>\n<p>See <a href=\"http://www.espruino.com/Assembler\">the documentation on the Assembler</a> for more information.</p>\n",
       "!url": "http://www.espruino.com/Reference#l_E_asm"
     },
+    "compiledC": {
+      "!type": "fn(callspec: ?)",
+      "!doc": "<p>Provide inline c code to Espruino.</p>\n<p><strong>This function is not part of Espruino</strong>. Instead, it is detected\nby the Espruino IDE (or command-line tools) at upload time and is\nreplaced with machine code and an <code>E.nativeCall</code> call.</p>\n<p>See <a href=\"http://www.espruino.com/InlineC\">the documentation on the inline c compiler</a> for more information.</p>\n",
+      "!url": "http://www.espruino.com/Reference#l_E_compiledC"
+    },
     "reboot": {
       "!type": "fn()",
       "!doc": "<p>Forces a hard reboot of the microcontroller - as close as possible\nto if the reset pin had been toggled.</p>\n<p><strong>Note:</strong> This is different to <code>reset()</code>, which performs a software\nreset of Espruino (resetting the interpreter and pin states, but not\nall the hardware)</p>\n",

--- a/info/Assembler.md
+++ b/info/Assembler.md
@@ -370,7 +370,9 @@ In order to be properly useful you'll probably want to access the current time:
 Compiling C Code
 --------------
 
-While you can't directly inline C code (yet!), once you have [installed a toolchain that will compile Espruino](https://github.com/espruino/Espruino/blob/master/README.md#building), you can compile C code with:
+You can also inline compile C code by using the [Inline C Compiler](/InlineC).
+
+Another way to compile C code is to use the [toolchain that will compile Espruino](https://github.com/espruino/Espruino/blob/master/README.md#building):
 
 ```Bash
 arm-none-eabi-gcc -mlittle-endian -mthumb -mcpu=cortex-m3  -mfix-cortex-m3-ldrd  -mthumb-interwork -mfloat-abi=soft -nostdinc -nostdlib -c test.c -o test.o


### PR DESCRIPTION
So far a reference to the inline c compiler was missing. Even worse it was mentioned that it is not yet possible (while it is). This has been fixed to a degree that at least a reference is presented.