### PR TITLE
SH1107 module

### DIFF
--- a/devices/SH1107.js
+++ b/devices/SH1107.js
@@ -1,0 +1,129 @@
+/* Copyright (c) 2014 Sam Sykes, Gordon Williams, Jonathan Richards.
+   See the file LICENSE for copying permission. */
+/* 
+Module for the SH1107 OLED controller (same as the SH1106, with different initialisation commands)
+```
+function go(){
+   // write some text
+   g.drawString("Hello World!",2,2);
+   // write to the screen
+   g.flip(); 
+}
+// I2C
+I2C1.setup({scl:B6,sda:B7});
+var g = require("SH1107").connect(I2C1, go, { address: 0x3C });
+// SPI
+SPI2.setup({mosi: B15, sck: B13});
+var g = require("SH1107").connectSPI(SPI2, B14, B10, go, {cs: B1, height: 64});
+```
+*/
+
+var C = {
+    OLED_WIDTH                 : 128,
+    OLED_CHAR                  : 0x40,
+};
+
+// commands sent when initialising the display
+var initCmds = new Uint8Array([ 0xAE, // 0 disp off
+                                0xD5, // 1 clk div
+                                0x80, // 2 suggested ratio
+                                0xA8, 0x7F, // 3 set multiplex
+                                0xD3, 0x62, // 5 display offset
+                                0x40, // 7 start line
+                                0xAD,0x8B, // 8 enable charge pump
+                                0xA1, // 10 seg remap 1, pin header at the top
+                                0xC8, // 11 comscandec, pin header at the top
+                                0xDA,0x12, // 12 set compins
+                                0x81,0x80, // 14 set contrast
+                                0xD9,0x22, // 16 set precharge
+                                0xDB,0x40, // 18 set vcom detect
+                                0xA6, // 20 display normal (non-inverted)
+                                0xAF // 21 disp on
+                              ]);
+
+function update(options) {
+    if (options && options.height) {
+        initCmds[4] = options.height-1;
+		initCmds[13] = options.height==64 ? 0x12 : 0x02;
+	}
+	if (options && options.contrast) {
+		initCmds[15] = options.contrast;
+	}
+}
+
+exports.connect = function(i2c, callback, options) {
+    update(options);
+    var oled = Graphics.createArrayBuffer(C.OLED_WIDTH,(initCmds[4] + 1),1,{vertical_byte : true});
+	var addr = 0x3C;
+	if(options && options.address) addr = options.address;
+
+    // configure the OLED
+    initCmds.forEach(function(d) {i2c.writeTo(addr, [0,d]);});
+    // if there is a callback, call it now(ish)
+    if (callback !== undefined) setTimeout(callback, 10);
+    
+    // write to the screen
+    oled.flip = function() { 
+        // chip only has page mode
+        var page = 0xB0;
+        var chunk = new Uint8Array(C.OLED_WIDTH+1);
+
+        chunk[0] = C.OLED_CHAR;
+        for (var p=0; p<(C.OLED_WIDTH * initCmds[4] / 8); p+=C.OLED_WIDTH) {
+			i2c.writeTo(addr, [0, page, 0x02, 0x10]);// display is centred in RAM
+			page++;
+            chunk.set(new Uint8Array(this.buffer,p,C.OLED_WIDTH), 1);
+            i2c.writeTo(addr, chunk);
+        } 
+    };
+    
+	// set contrast, 0..255
+	oled.setContrast = function(c) { i2c.writeTo(addr, 0, 0x81, c); };
+
+    // return graphics
+    return oled;
+};
+exports.connectSPI = function(spi, dc,  rst, callback, options) {
+    update(options);
+    var cs = options?options.cs:undefined;
+    var oled = Graphics.createArrayBuffer(C.OLED_WIDTH,(initCmds[4] + 1),1,{vertical_byte : true});
+    
+    if (rst) digitalPulse(rst,0,10);
+    setTimeout(function() {
+        // configure the OLED
+        if (cs) digitalWrite(cs,0);
+        digitalWrite(dc,0); // command
+        spi.write(initCmds);
+        digitalWrite(dc,1); // data
+        if (cs) digitalWrite(cs,1);
+        // if there is a callback, call it now(ish)
+        if (callback !== undefined) setTimeout(callback, 10);
+    }, 50);
+    
+    // write to the screen
+    oled.flip = function() { 
+        //  chip only has page mode
+        var page = 0xB0;
+        var chunk = new Uint8Array(C.OLED_WIDTH);
+        if (cs) digitalWrite(cs,0);
+        for (var p=0; p<(C.OLED_WIDTH * initCmds[4] / 8); p+=C.OLED_WIDTH) {
+            digitalWrite(dc,0); // command
+            spi.write([page, 0x02, 0x10]);// display is centred in RAM
+            page++;
+            digitalWrite(dc,1);// data
+            chunk.set(new Uint8Array(this.buffer,p,C.OLED_WIDTH), 0);
+            spi.write(chunk);
+        }
+        if (cs) digitalWrite(cs,1);
+    };
+    
+	// set contrast, 0..255
+	oled.setContrast = function(c) { 
+		if (cs) cs.reset();
+		spi.write(0x81,c,dc);
+		if (cs) cs.set();
+	};
+
+    // return graphics
+    return oled;
+};

--- a/devices/SH1107.md
+++ b/devices/SH1107.md
@@ -59,12 +59,12 @@ function start(){
 
 // I2C
 I2C1.setup({scl:B6,sda:B7});
-var g = require("SH1106").connect(I2C1, start);
+var g = require("SH1107").connect(I2C1, start);
 
 // SPI
 var s = new SPI();
 s.setup({mosi: B6 /* D1 */, sck:B5 /* D0 */});
-var g = require("SH1106").connectSPI(s, A8 /* DC */, B7 /* RST - can leave as undefined */, start);
+var g = require("SH1107").connectSPI(s, A8 /* DC */, B7 /* RST - can leave as undefined */, start);
 ```
 
 **Note:** This module uses a double buffer, which means you need to call ```g.flip()``` before any changes take effect.
@@ -85,7 +85,7 @@ require("SH1107").connectSPI(s, A8 /* DC */, B7 /* RST */, start, { height : 32 
 By default, chip select on the SPI OLEDs isn't used. You can however enable it with the following:
 
 ```
-require("SH1106").connectSPI(s, A8 /* DC */, B7 /* RST */, start, { cs : MY_CS_PIN });
+require("SH1107").connectSPI(s, A8 /* DC */, B7 /* RST */, start, { cs : MY_CS_PIN });
 ```
 
 ### Non-standard I2C addresses
@@ -97,7 +97,7 @@ Also, if pin DC is tied to 3.3V.
 If this is the case then you'll have to explicitly specify the address:
 
 ```
-require("SH1106").connect(I2C1, start, { address : 0x3D });
+require("SH1107").connect(I2C1, start, { address : 0x3D });
 ```
 
 ### Contrast
@@ -107,7 +107,7 @@ You can set the contrast after initialisation using `g.setContrast(31)` with a v
 However you can also set this at startup, using the `options` object:
 
 ```
-require("SH1106").connect(I2C1, start, { 
+require("SH1107").connect(I2C1, start, { 
   contrast : 31,
 });
 ```

--- a/devices/SH1107.md
+++ b/devices/SH1107.md
@@ -1,0 +1,126 @@
+<!--- Copyright (c) 2015 J H Richards. See the file LICENSE for copying permission. -->
+SH1107 OLED driver
+=====================
+
+<span style="color:red">:warning: **Please view the correctly rendered version of this page at https://www.espruino.com/SH1107. Links, lists, videos, search, and other features will not work correctly when viewed on GitHub** :warning:</span>
+
+* KEYWORDS: Module,I2C,SPI,SH1107,Graphics,Graphics Driver,OLED,Monochrome
+
+Support is included in the [[SH1107.js]] module, using the [[Graphics]] library.
+
+This module is very similar to the [SH1106](https://www.espruino.com/SH1106) module, but with different initialisation commands to make it work with the SH1107. This hasn't been tested with 128x128 displays, only a 128x64 display.
+
+The display shown can be set to operate in one of three modes by changing links on the pcb.
+
+The modes are 4-wire SPI (with a D/C pin), 3-wire SPI, and I2C.
+
+Other variants have only the I2C mode available, and 4 pins on the header: VCC, GND SDA & SCL.
+
+SPI
+---
+
+SPI 3-wire isn't supported by this driver, only 4-wire is.
+
+| OLED pin  | Example pin on Espruino Board |
+|-----------|-------------------------------|
+| GND       | GND |
+| VCC/3.3V       | 3.3V |
+| D0/SCK/SCLK    | B13 |
+| D1/MOSI/SDIN   | B15 |
+| DC        | B14 |
+| RST       | B10 (if you have this pin) |
+| CE/CS     | B1 (if you have this pin - see the Software section for more info) |
+
+I2C
+---
+
+Just wire up as follows:
+
+| OLED pin | Example pin on Espruino Board |
+|----------|-------------------------------|
+| GND      | GND |
+| VCC    | 3.3V |
+| SDA (D1)    | B7 |
+| SCL (D0)  | B6 |
+| RST | 3.3V (if you have this pin) |
+| DC | GND, address = 0x3C; 3.3V, address = 0x3D (if you have this pin) |
+| CS | GND or 3.3V, has no effect (if you have this pin) |
+
+Software
+-------
+
+```
+function start(){
+ // write some text
+ g.drawString("Hello World!",2,2);
+ // write to the screen
+ g.flip(); 
+}
+
+// I2C
+I2C1.setup({scl:B6,sda:B7});
+var g = require("SH1106").connect(I2C1, start);
+
+// SPI
+var s = new SPI();
+s.setup({mosi: B6 /* D1 */, sck:B5 /* D0 */});
+var g = require("SH1106").connectSPI(s, A8 /* DC */, B7 /* RST - can leave as undefined */, start);
+```
+
+**Note:** This module uses a double buffer, which means you need to call ```g.flip()``` before any changes take effect.
+
+### 128x32 or 128x128
+
+By default the module is configured for 128x64 OLEDs. If you want to use 128x32 or 128x128 OLEDs, you must specify the height in the optional last argument. This has not yet been tried.
+
+```
+// I2C
+require("SH1107").connect(I2C1, start, { height : 32 });
+// SPI
+require("SH1107").connectSPI(s, A8 /* DC */, B7 /* RST */, start, { height : 32 });
+```
+
+### Chip Select (CS)
+
+By default, chip select on the SPI OLEDs isn't used. You can however enable it with the following:
+
+```
+require("SH1106").connectSPI(s, A8 /* DC */, B7 /* RST */, start, { cs : MY_CS_PIN });
+```
+
+### Non-standard I2C addresses
+
+Some I2C modules are configured such that they aren't on the normal I2C address of 0x3C.
+
+Also, if pin DC is tied to 3.3V.
+
+If this is the case then you'll have to explicitly specify the address:
+
+```
+require("SH1106").connect(I2C1, start, { address : 0x3D });
+```
+
+### Contrast
+
+You can set the contrast after initialisation using `g.setContrast(31)` with a value between 0 and 255.
+
+However you can also set this at startup, using the `options` object:
+
+```
+require("SH1106").connect(I2C1, start, { 
+  contrast : 31,
+});
+```
+
+### ESP32 / M5Stick configuration
+To use this module with the display in the [M5Stick](https://docs.m5stack.com/#/en/core/m5stick), you need the following configuration:
+
+```
+SPI2.setup({ sck:D18, mosi:D23 });
+var g = require("SH1107").connectSPI(SPI2, D27, D33, start, {cs: D14});
+```
+
+Using 
+-----
+
+* APPEND_USES: SH1107


### PR DESCRIPTION
I managed to get a SH1107 display (from the [M5Stick](https://docs.m5stack.com/#/en/core/m5stick)) to work with Espruino. The module is exactly the same as the SH1106, but with a couple of modifications to the initialisation commands.

This hasn't been tested with 128x128 or 128x32 displays, but the original module had code for 128x32 displays so it might work.