### PR TITLE
Fixed MQ135.js resistance calculation

### DIFF
--- a/devices/MQ135.js
+++ b/devices/MQ135.js
@@ -48,7 +48,7 @@ function MQ135(pin) {
  * Get the resistance of the sensor (in KOhm)
  */
 MQ135.prototype.getResistance = function() {
-  return ((1023/analogRead(this.PIN)) * 5 - 1)*this.RLOAD;
+  return ((1/analogRead(this.PIN)) * 5 - 1)*this.RLOAD;
 }
 
 /**


### PR DESCRIPTION
Resistance calculation used a constant from Arduino which analogRead returns a value between 0 and 1023 whereas Espruino returns between 0 and 1.