### PR TITLE
Smart meter slightly broken formatting

### DIFF
--- a/tutorials/Smart Meter.md
+++ b/tutorials/Smart Meter.md
@@ -86,8 +86,6 @@ To use this:
 
 ```JavaScript
 /** Create a new counter. Contains the following:
-
-```
 {
   totals : {
     count // Overall count
@@ -98,7 +96,6 @@ To use this:
   },
   history // last 96 hours, newest last (0..95)
 }
-```
 */
 function Counter() {
   this.clear();


### PR DESCRIPTION
The sample after "Create a new counter. Contains the following:" is broken.
Looks like this:
![image](https://user-images.githubusercontent.com/844331/55885976-30562d00-5bab-11e9-938c-6ac648067ba8.png)
