### PR TITLE
Changed BME280 Module to option address

### DIFF
--- a/devices/BME280.js
+++ b/devices/BME280.js
@@ -141,11 +141,12 @@ BME280.prototype.getData = function() {
 };
 
 exports.connect = function(i2c, options) {
-  return (new BME280(options, function(reg, len) { // read
-    i2c.writeTo(C.BME280_ADDRESS, reg);
-    return i2c.readFrom(C.BME280_ADDRESS, len);
+    var addr = (options&&options.addr)||C.BME280_ADDRESS;
+      return (new BME280(options, function(reg, len) { // read
+    i2c.writeTo(addr, reg);
+    return i2c.readFrom(addr, len);
   }, function(reg, data) { // write
-    i2c.writeTo(C.BME280_ADDRESS, [reg, data]);
+    i2c.writeTo(addr, [reg, data]);
   }));
 };
 

--- a/devices/BME280.md
+++ b/devices/BME280.md
@@ -44,7 +44,16 @@ console.log(bme.getData());
 
 ```
 I2C1.setup({scl:B8,sda:B9});
-var bme = require("BME280").connect(I2C1);;
+var bme = require("BME280").connect(I2C1);
+console.log(bme.getData());
+// prints { "temp": 23.70573815741, "pressure": 1017.27733597036, "humidity": 42.0771484375 }
+```
+
+### Simple I2C (with Alternative I2C address)
+
+```
+I2C1.setup({scl:B8,sda:B9});
+var bme = require("BME280").connect(I2C1,{addr: 0x77});  // use alternate I2C address
 console.log(bme.getData());
 // prints { "temp": 23.70573815741, "pressure": 1017.27733597036, "humidity": 42.0771484375 }
 ```


### PR DESCRIPTION
Updated BME280 module so that the I2C address could be overridden with a connect() option.