### PR TITLE
NRF24L01P.js: add setChannel, setAutoAck and disableCRC

### DIFF
--- a/devices/NRF24L01P.js
+++ b/devices/NRF24L01P.js
@@ -203,6 +203,21 @@ NRF.prototype.setDataRate = function(rate) {
 NRF.prototype.setTXPower = function(pwr) {
   this.setReg(C.RF_SETUP, (this.getReg(C.RF_SETUP)&~(3*C.RF_PWR))|((pwr&3)*C.RF_PWR));
 };
+/** Set RF channel, from 0 to 125 */
+NRF.prototype.setChannel = function(channel) {
+  this.setReg(C.RF_CH, channel);
+}
+NRF.prototype.disableCRC = function() {
+  this.setReg(C.CONFIG, this.getReg(C.CONFIG) & (~C.EN_CRC));
+  BASE_CONFIG &= ~C.EN_CRC;
+}
+NRF.prototype.setAutoAck = function(enable) {
+  if (enable) {
+    this.setReg(C.EN_AA, 0x3f);
+  } else {
+    this.setReg(C.EN_AA, 0);
+  }
+}
 /** return undefined (if no data) or the pipe number of the data we're expecting */
 NRF.prototype.getDataPipe = function() {
   var r = this.getReg(C.STATUS)&C.RX_P_NO_FIFO_EMPTY;


### PR DESCRIPTION
Tested on ESP8266. I've used new functions to receive data from quadcopter controller.

```js
const NRF = require("NRF24L01P");
const nrf = NRF.connect( SPI1, CSN, CE, 10 );
nrf.init([0xca, 0xca, 0xca, 0xca, 0xca], [0xca, 0xca, 0xca, 0xca, 0xcb]);
nrf.setDataRate(1000000);
nrf.setChannel(60);
nrf.setAutoAck(false);
nrf.disableCRC();
```