### PR TITLE
Font4x5Numeric.js:Fix '6' character

### DIFF
--- a/modules/Font4x5Numeric.js
+++ b/modules/Font4x5Numeric.js
@@ -29,9 +29,9 @@
 # # #
 # ###
 
-### #
-# # #
 #####
+# # #
+# ###
 
 #
 #
@@ -51,6 +51,6 @@ this.setFontCustom(font, 46, widths, 5);
 
 exports.add = function(graphics) {
   graphics.prototype.setFont4x5Numeric = function() {
-    this.setFontCustom(atob("CAZMA/H4PgvXoK1+DhPg7W4O1+CEPg/X4O1+AA=="), 46, atob("AgQEAgQEBAQEBAQE"), 5);
+    this.setFontCustom(atob("CAZMA/H4PgvXoK1+DhPg7W4P1uCEPg/X4O1+AA=="), 46, atob("AgQEAgQEBAQEBAQE"), 5);
   }
 }


### PR DESCRIPTION
Fixes the '6' character. It was a copy of the '9'.