### PR TITLE
Added gain:1/4 and refvdd:true to the new sample

### DIFF
--- a/devices/NRF52LL.md
+++ b/devices/NRF52LL.md
@@ -173,9 +173,13 @@ var buf = new Int16Array(128);
 // ADC
 var saadc = ll.saadc({
   channels : [ {
-    pin:D31 // channel 0
+    pin:D31, // channel 0    
+    gain:1/4,
+    refvdd:true
   }, {
-    pin:D30 // channel 1
+    pin:D30, // channel 1
+    gain:1/4,
+    refvdd:true
   } ],
   dma:{ptr:E.getAddressOf(buf,true), cnt:buf.length},
 });


### PR DESCRIPTION
Because otherwise it's pretty easy to jump out of the valid range (0.6V reference by default). And to match the other samples.

And the misleading about the over-range was that all values (at least for me) were 16380. And that's not the maximum valid value for 14 bits, but 4 lower. It was obviously wrong, but spent a couple of minutes trying to figure out what might be wrong...

On the positive side: It's working now :)