### PR TITLE
INA226 small fixes

### DIFF
--- a/devices/INA226.md
+++ b/devices/INA226.md
@@ -17,7 +17,8 @@ along with a shunt resistor pre-wired:
 
 Wiring
 ------
-
+| INA226 | Espruino |
+|--------|----------|
 | IN+ | Shunt side 1 - DON'T CONNECT TO ESPRUINO |
 | IN- | Shunt side 2 - DON'T CONNECT TO ESPRUINO |
 | VBS | Voltage being measured - connect to one side of the shunt or the other (depending which voltage you want to measure) |
@@ -32,7 +33,7 @@ Wiring
 Usage
 -----
 
-Usage is pretty straightforward. 
+Usage is pretty straightforward.
 
 In this example `SCL` is connected to `B3`, and `SDA` is connected to `B4` - software I2C
 is being used so you could connect using any available pins.
@@ -43,7 +44,7 @@ var i2c = new I2C();
 i2c.setup({sda:B4, scl:B3});
 // initialise INA226
 var INA226 = require("INA226");
-var ina = new INA226(i2c, { 
+var ina = new INA226(i2c, {
   average:1024, // how many samples to take and average (1024 = about 1 reading a second)
   shunt:0.1, // the shunt resistor's value
   maxCurrent: 10  // max current we expect to measure (the lower this is the more accurate measurements are)
@@ -51,11 +52,11 @@ var ina = new INA226(i2c, {
 // You can now simply read the data
 print(ina.read());
 /* Outputs something like:
-{ "vshunt": 0.024475, 
-  "vbus": 9.80875, 
-  "power": 0.23651123046, 
+{ "vshunt": 0.024475,
+  "vbus": 9.80875,
+  "power": 0.23651123046,
   "current": 0.0244140625,
-  "overflow": false 
+  "overflow": false
 }
 */
 ```


### PR DESCRIPTION
Fixes:
 - wiring table broken
 - vshunt calculation off by 10

Some tweaks:
 - `if (options.average) {` not needed, since always has value (the line above)
 - ~~`this.i2c.writeTo(this.addr,[a,d>>8,d&0xff]);` can be simplified to `this.i2c.writeTo(this.addr,[a,d]);`~~