### PR TITLE
adding SSD1306 64x48 functionality

### DIFF
--- a/devices/SSD1306.js
+++ b/devices/SSD1306.js
@@ -14,6 +14,10 @@ I2C1.setup({scl:B6,sda:B7});
 var g = require("SSD1306").connect(I2C1, go);
 // or
 var g = require("SSD1306").connect(I2C1, go, { address: 0x3C });
+// or 
+var g = connect(I2C1,start, { height : 48, width:64 });  // for 64x48 LCD
+// or 
+var g = connect(I2C1,start, { height : 32 });  // for 128x32 LCD
 
 // SPI
 var s = new SPI();
@@ -22,144 +26,149 @@ var g = require("SSD1306").connectSPI(s, A8, B7, go);
 ```
 */
 var C = {
- OLED_WIDTH                 : 128,
- OLED_CHAR                  : 0x40,
- OLED_CHUNK                 : 128
-};
-
-// commands sent when initialising the display
-var extVcc=false; // if true, don't start charge pump 
-var initCmds = new Uint8Array([ 
-             0xAe, // 0 disp off
-             0xD5, // 1 clk div
-             0x80, // 2 suggested ratio
-             0xA8, 63, // 3 set multiplex, height-1
-             0xD3,0x0, // 5 display offset
-             0x40, // 7 start line
-             0x8D, extVcc?0x10:0x14, // 8 charge pump
-             0x20,0x0, // 10 memory mode
-             0xA1, // 12 seg remap 1
-             0xC8, // 13 comscandec
-             0xDA, 0x12, // 14 set compins, height==64 ? 0x12:0x02,
-             0x81, extVcc?0x9F:0xCF, // 16 set contrast
-             0xD9, extVcc?0x22:0xF1, // 18 set precharge
-             0xDb, 0x40, // 20 set vcom detect
-             0xA4, // 22 display all on
-             0xA6, // 23 display normal (non-inverted)
-             0xAf // 24 disp on
-            ]);
-// commands sent when sending data to the display
-var flipCmds = [
-     0x21, // columns
-     0, C.OLED_WIDTH-1,
-     0x22, // pages
-     0, 7 /* (height>>3)-1 */];
-function update(options) {
-  if (options) {
-    if (options.height) {
-      initCmds[4] = options.height-1;
-      initCmds[15] = options.height==64 ? 0x12 : 0x02;
-      flipCmds[5] = (options.height>>3)-1;
-    }
-    if (options.contrast!==undefined) initCmds[17] = options.contrast;
-  }
-}
-
-
-exports.connect = function(i2c, callback, options) {
-  update(options);
-  var oled = Graphics.createArrayBuffer(C.OLED_WIDTH,initCmds[4]+1,1,{vertical_byte : true});
-
-  var addr = 0x3C;
-  if(options) {
-    if (options.address) addr = options.address;  
-    // reset display if 'rst' is part of options 
-    if (options.rst) digitalPulse(options.rst, 0, 10); 
-  }
-  
-  setTimeout(function() {
-    // configure the OLED
-    initCmds.forEach(function(d) {i2c.writeTo(addr, [0,d]);});
-  }, 50);
-
-  // if there is a callback, call it now(ish)
-  if (callback !== undefined) setTimeout(callback, 100);
-
-  // write to the screen
-  oled.flip = function() { 
-    // set how the data is to be sent (whole screen)
-    flipCmds.forEach(function(d) {i2c.writeTo(addr, [0,d]);});
-    var chunk = new Uint8Array(C.OLED_CHUNK+1);
-
-    chunk[0] = C.OLED_CHAR;
-    for (var p=0; p<this.buffer.length; p+=C.OLED_CHUNK) {
-      chunk.set(new Uint8Array(this.buffer,p,C.OLED_CHUNK), 1);
-      i2c.writeTo(addr, chunk);
-    } 
-  };
-
-  // set contrast, 0..255
-  oled.setContrast = function(c) { i2c.writeTo(addr, 0, 0x81, c); };
-
-  // set off
-  oled.off = function() { i2c.writeTo(addr, 0, 0xAE); }
-
-  // set on
-  oled.on = function() { i2c.writeTo(addr, 0, 0xAF); }
-
-  // return graphics
-  return oled;
-};
-
-exports.connectSPI = function(spi, dc,  rst, callback, options) {
-  update(options);
-  var cs = options?options.cs:undefined;
-  var oled = Graphics.createArrayBuffer(C.OLED_WIDTH,initCmds[4]+1,1,{vertical_byte : true});
-
-  if (rst) digitalPulse(rst,0,10);
-  setTimeout(function() {
-    if (cs) digitalWrite(cs,0);
-    // configure the OLED
-    digitalWrite(dc,0); // command
-    spi.write(initCmds);
-    digitalWrite(dc,1); // data
-    if (cs) digitalWrite(cs,10);
-    // if there is a callback, call it now(ish)
-    if (callback !== undefined) setTimeout(callback, 10);
-  }, 50);
-
-  // write to the screen
-  oled.flip = function() { 
-    // set how the data is to be sent (whole screen)
-    if (cs) digitalWrite(cs,0);
-    digitalWrite(dc,0);// command
-    spi.write(flipCmds);
-    digitalWrite(dc,1);// data
-    spi.write(this.buffer);
-    if (cs) digitalWrite(cs,1);
-  };
-
-  // set contrast, 0..255
-  oled.setContrast = function(c) { 
-    if (cs) cs.reset();
-    spi.write(0x81,c,dc);
-    if (cs) cs.set();
-  };
-
-  // set off
-  oled.off = function() { 
-    if (cs) cs.reset();
-    spi.write(0xAE,dc);
-    if (cs) cs.set();
-  };
-
-  // set on
-  oled.on = function() { 
-    if (cs) cs.reset();
-    spi.write(0xAF,dc);
-    if (cs) cs.set();
-  };
-
-  // return graphics
-  return oled;
-};
+  OLED_WIDTH                 : 128,
+  OLED_CHAR                  : 0x40,
+  OLED_CHUNK                 : 128
+ };
+ 
+ // commands sent when initialising the display
+ var extVcc=false; // if true, don't start charge pump 
+ var initCmds = new Uint8Array([ 
+              0xAe, // 0 disp off
+              0xD5, // 1 clk div
+              0x80, // 2 suggested ratio
+              0xA8, 63, // 3 set multiplex, height-1
+              0xD3,0x0, // 5 display offset
+              0x40, // 7 start line
+              0x8D, extVcc?0x10:0x14, // 8 charge pump
+              0x20,0x0, // 10 memory mode
+              0xA1, // 12 seg remap 1
+              0xC8, // 13 comscandec
+              0xDA, 0x12, // 14 set compins, height==64 ? 0x12:0x02,
+              0x81, extVcc?0x9F:0xCF, // 16 set contrast
+              0xD9, extVcc?0x22:0xF1, // 18 set precharge
+              0xDb, 0x40, // 20 set vcom detect
+              0xA4, // 22 display all on
+              0xA6, // 23 display normal (non-inverted)
+              0xAf // 24 disp on
+             ]);
+ // commands sent when sending data to the display
+ var flipCmds = [
+      0x21, // columns
+      0, C.OLED_WIDTH-1,
+      0x22, // pages
+      0, 7 /* (height>>3)-1 */];
+ function update(options) {
+   if (options) {
+     if (options.height) {
+       initCmds[4] = options.height-1;
+       initCmds[15] = options.height==64 || options.height==48 ? 0x12 : 0x02;
+       flipCmds[5] = (options.height>>3)-1;
+     }
+     if (options.width) {
+       C.OLED_WIDTH = options.width;
+       flipCmds[1] = options.width < 128 ? options.width/2 : options.width; // 0x20 for 64;
+       flipCmds[2] =options.width < 128 ? flipCmds[1]+options.width-1 : options.width-1; // 0x5f;
+     }
+     if (options.contrast!==undefined) initCmds[17] = options.contrast;
+   }
+ }
+ 
+ 
+ exports.connect = function(i2c, callback, options) {
+   update(options);
+   var oled = Graphics.createArrayBuffer(C.OLED_WIDTH,initCmds[4]+1,1,{vertical_byte : true});
+ 
+   var addr = 0x3C;
+   if(options) {
+     if (options.address) addr = options.address;  
+     // reset display if 'rst' is part of options 
+     if (options.rst) digitalPulse(options.rst, 0, 10); 
+   }
+   
+   setTimeout(function() {
+     // configure the OLED
+     initCmds.forEach(function(d) {i2c.writeTo(addr, [0,d]);});
+   }, 50);
+ 
+   // if there is a callback, call it now(ish)
+   if (callback !== undefined) setTimeout(callback, 100);
+ 
+   // write to the screen
+   oled.flip = function() { 
+     // set how the data is to be sent (whole screen)
+     flipCmds.forEach(function(d) {i2c.writeTo(addr, [0,d]);});
+     var chunk = new Uint8Array(C.OLED_CHUNK+1);
+ 
+     chunk[0] = C.OLED_CHAR;
+     for (var p=0; p<this.buffer.length; p+=C.OLED_CHUNK) {
+       chunk.set(new Uint8Array(this.buffer,p,C.OLED_CHUNK), 1);
+       i2c.writeTo(addr, chunk);
+     } 
+   };
+ 
+   // set contrast, 0..255
+   oled.setContrast = function(c) { i2c.writeTo(addr, 0, 0x81, c); };
+ 
+   // set off
+   oled.off = function() { i2c.writeTo(addr, 0, 0xAE); }
+ 
+   // set on
+   oled.on = function() { i2c.writeTo(addr, 0, 0xAF); }
+ 
+   // return graphics
+   return oled;
+ };
+ 
+ exports.connectSPI = function(spi, dc,  rst, callback, options) {
+   update(options);
+   var cs = options?options.cs:undefined;
+   var oled = Graphics.createArrayBuffer(C.OLED_WIDTH,initCmds[4]+1,1,{vertical_byte : true});
+ 
+   if (rst) digitalPulse(rst,0,10);
+   setTimeout(function() {
+     if (cs) digitalWrite(cs,0);
+     // configure the OLED
+     digitalWrite(dc,0); // command
+     spi.write(initCmds);
+     digitalWrite(dc,1); // data
+     if (cs) digitalWrite(cs,10);
+     // if there is a callback, call it now(ish)
+     if (callback !== undefined) setTimeout(callback, 10);
+   }, 50);
+ 
+   // write to the screen
+   oled.flip = function() { 
+     // set how the data is to be sent (whole screen)
+     if (cs) digitalWrite(cs,0);
+     digitalWrite(dc,0);// command
+     spi.write(flipCmds);
+     digitalWrite(dc,1);// data
+     spi.write(this.buffer);
+     if (cs) digitalWrite(cs,1);
+   };
+ 
+   // set contrast, 0..255
+   oled.setContrast = function(c) { 
+     if (cs) cs.reset();
+     spi.write(0x81,c,dc);
+     if (cs) cs.set();
+   };
+ 
+   // set off
+   oled.off = function() { 
+     if (cs) cs.reset();
+     spi.write(0xAE,dc);
+     if (cs) cs.set();
+   };
+ 
+   // set on
+   oled.on = function() { 
+     if (cs) cs.reset();
+     spi.write(0xAF,dc);
+     if (cs) cs.set();
+   };
+ 
+   // return graphics
+   return oled;
+ };

--- a/devices/SSD1306.js
+++ b/devices/SSD1306.js
@@ -67,8 +67,8 @@ var C = {
      }
      if (options.width) {
        C.OLED_WIDTH = options.width;
-       flipCmds[1] = options.width < 128 ? options.width/2 : options.width; // 0x20 for 64;
-       flipCmds[2] =options.width < 128 ? flipCmds[1]+options.width-1 : options.width-1; // 0x5f;
+       flipCmds[1] = (128-options.width)/2; // 0x20 for 64, 0 for 128;
+       flipCmds[2] = flipCmds[1]+options.width-1; // 0x5f;
      }
      if (options.contrast!==undefined) initCmds[17] = options.contrast;
    }

--- a/devices/SSD1306.md
+++ b/devices/SSD1306.md
@@ -96,6 +96,16 @@ Using these is much like using the 32 pixel high OLEDs - just initialise with a 
 require("SSD1306").connect(I2C1, start, { height : 16 });
 ```
 
+### 64x48
+
+By default the SSD1306 module is designed for 128 width OLEDs. 
+By specifying the height and width we can work with certain other widths.
+
+```
+// I2C
+require("SSD1306").connect(I2C1,start, { height : 48, width:64 });
+```
+
 ### Chip Select (CS)
 
 By default, chip select on the SPI OLEDs isn't used. You can however enable it with the following:


### PR DESCRIPTION
Adding the 64x48 OLED to the amazing SSSD1306

This has been tested on a D1 oled shield v2 (64x48) and with the HELTEC 128x32 (for backward compatibility) with the code below:

NOTE. Only lines 65 and 68-72 where changed is the JS file. 
Silly Git doesn't realize only these changes were made because of spacing or CR/LF issues.

I've also added the notes to the Espruino/SSD1306 MD file and examples to the top of the JS file

```
function start(){
  g.clear();
  g.drawString("Hello",0,0);
  g.drawLine(0, 20, g.getWidth(), 20);
  g.setFontVector(10);
  g.drawString("123456789",0,7);
  g.drawString("123456789",0,22);
  g.drawString("123456789",0,35);
  g.flip();
}
// HELTEC 128x32
let SCL = D5;
let SDA = D4;
I2C1.setup({scl:SCL,sda:SDA});
var g = connect(I2C1, start, { height : 32 });

//D1.Mini OLED 64x48
let SCL = NodeMCU.D1;
let SDA = NodeMCU.D2;
I2C1.setup({scl:SCL,sda:SDA});
var g = connect(I2C1,start, { height : 48, width:64 });

```