### PR TITLE
Update install experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ references.json
 /.project
 npm-debug.log
 orig
+ordering.txt
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If you haven't got Node.js JavaScript runtime installed or the JavaScript Packag
 * [Mac Installation Guide](http://treehouse.github.io/installation-guides/mac/node-mac.html)
 * [Linux Installation Guide](http://treehouse.github.io/installation-guides/linux/node-linux.html)
 
-
+On Linux, you may have `nodejs` and not `node` in your path. This will lead to issues later on in the build process. This problem is easily solved by running `sudo ln -s /usr/bin/nodejs /usr/bin/node` which will create a symbolic link, so you can use both `node` and `nodejs` at the terminal.
 
 ### Step 3: Install Required Node Modules
 
@@ -114,7 +114,7 @@ In order to generate the documentation and view it you require several JavaScrip
 $ npm install
 ```
 
-This will install all JavaScript dependancies.
+This will install all JavaScript dependencies.
 
 ## Build Process
 

--- a/app.js
+++ b/app.js
@@ -4,7 +4,12 @@ var express = require('express');
 var app = express();
 
 app.all('/*', function(req, res, next) {
-  if (!req.url.match(/.*\/?\./)) {
+  // The root page is part of the large site and so is not available
+  // locally. Instead we default to a given page to kick off.
+  if (req.url === '/') {
+    res.redirect('/Original.html');
+    return next();
+  } else if (!req.url.match(/.*\/?\./)) {
     req.url += '.html';
   }
   console.log('returning: ' + req.url);

--- a/bin/fontpreview.js
+++ b/bin/fontpreview.js
@@ -1,4 +1,4 @@
-#!/bin/nodejs
+#!/bin/node
 /* Creates a URL-encoded preview image of an Espruino bitmap font */
 
 global.atob = function(a) {

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ rm -f html/*.js
 rm -f html/refimages/*
 rm -f html/boards/*
 
-nodejs bin/commenter.js
+node bin/commenter.js
 
 cd ../Espruino
 
@@ -31,7 +31,7 @@ cd $DIR
 echo "Getting file modification times..."
 git ls-tree -r --name-only HEAD | xargs -I{} git log -1 --format="%at {}" -- {} | sort > ordering.txt
 # Built reference docs and references.json
-nodejs bin/build.js $BUILDARGS || exit 1
+node bin/build.js $BUILDARGS || exit 1
 
 #rm $WEBSITE/reference/*
 cp html/*.html $WEBSITE/reference/

--- a/buildmodules.sh
+++ b/buildmodules.sh
@@ -37,7 +37,7 @@ for module in $MODULES; do
   cp $module $MODULEDIR/$BNAME.js
 
   echo min $MODULEDIR/$module to $MINJS
-  nodejs bin/minify.js "$MODULEDIR/$BNAME.js" "$MODULEDIR/$MINJS" "$externsFile"
+  node bin/minify.js "$MODULEDIR/$BNAME.js" "$MODULEDIR/$MINJS" "$externsFile"
 
   if [[ -s $MODULEDIR/$MINJS ]] ; then
     echo "$MODULEDIR/$MINJS compile successful"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "espruino-docs",
   "version": "1.0.0",
-  "description": "Espruino Site, Documenation Tutorials and Modules",
+  "description": "Espruino Site, Documentation Tutorials and Modules",
   "main": "app.js",
   "scripts": {
-    "build": "nodejs ./bin/build.js",
+    "build": "node ./bin/build.js",
     "eslintdevices": "./node_modules/.bin/eslint devices/*.js",
     "eslintmodules": "./node_modules/.bin/eslint modules/*.js",
     "eslintboards": "./node_modules/.bin/eslint boards/*.js",
-    "start": "nodejs app.js"
+    "start": "node app.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Based on the discussion on #526:

I've opted to default to node to serve the majority on the basis that a user that knows Linux is far more likely to be able to run a symlink command than a user on say, Windows.

I've made other minor improvements is well, all in the vein that if someone does pull the code to build and view locally, it will run as expected with minimal effort or hiccup.

Please note the two files I ignored. I didn't see a package-lock checked in so I opted to ignore it, same for ordering.txt which is generated post build run.

Notes are:

- Change nodejs to node in all places
- Update docs to provide info on how to symlink to nodejs
- add some build bits to gitignore to prevent bad check-ins
- add redirect in start script to handle requests to /