### PR TITLE
Emit error on first time MQTT connection failure

### DIFF
--- a/modules/MQTT.js
+++ b/modules/MQTT.js
@@ -314,6 +314,7 @@ MQTT.prototype.connect = function (client) {
         client = require("net").connect({host: mqo.server, port: mqo.port}, onConnect);
       } catch (e) {
         this.client = false;
+        this.emit('error', e.message);
         this.emit('disconnected');
       }
     }


### PR DESCRIPTION
Emit an error if the client did not connect the first time. For instance, if the IP address is wrong you will get `Unable to create socket`. This is helpful so that disconnect / reconnect logic can take into account bad server ip without guessing the problem.