### PR TITLE
SX127x - RFM95W and TTGO LoRa32 transmission fix

### DIFF
--- a/devices/SX127x.md
+++ b/devices/SX127x.md
@@ -4,9 +4,9 @@ SX1276/77/78/79 LoRa Modules
 
 <span style="color:red">:warning: **Please view the correctly rendered version of this page at https://www.espruino.com/SX127x. Links, lists, videos, search, and other features will not work correctly when viewed on GitHub** :warning:</span>
 
-* KEYWORDS: Module,SX1276,SX1277,SX1278,Semtech,Modtronix,inAIR9,SPI,LoRa,Wireless,Radio,Transceiver
+* KEYWORDS: Module,SX1276,SX1277,SX1278,Semtech,Modtronix,inAIR9,SPI,LoRa,Wireless,Radio,Transceiver,RFM95W,RFM96W,RFM98W,TTGO LoRa32
 
-The [SX1276/77/78/79](http://www.semtech.com/wireless-rf/rf-transceivers/sx1276/) transceivers feature the LoRa® long range modem that provides ultra-long range spread spectrum communication.
+The [Semtech SX1276/77/78/79](http://www.semtech.com/wireless-rf/rf-transceivers/sx1276/) or [HopeRF RFM95W/96W/98W](https://www.hoperf.com/modules/lora/index.html) transceivers feature the LoRa® long range modem that provides ultra-long range spread spectrum communication.
 
 Espruino's [[SX127x.js]] module handles this, however **it is extremely beta**. Please feed back any issues on [GitHub](https://github.com/espruino/EspruinoDocs/issues/new?title=devices/SX127x.md) or [the Forum](http://forum.espruino.com).
 
@@ -52,17 +52,19 @@ However all options are shown below:
 
 ```
 var config = {
- power : 14, // dbM
- bandwidth // 0: 125 kHz, 1: 250 kHz, 2: 500 kHz
- datarate // spreading factor, 7..12  
- coderate // [1: 4/5, 2: 4/6, 3: 4/7, 4: 4/8]
- preambleLen : int // peramble length
+ power : 14, // transmit power in dBm, allowed range: -4 to +17dBm or 20dBm. If you use Hope RF or TTGO module see the note below!
+ freq: 868000000 // frequency in MHz, by default 868MHz
+ bandwidth : 0 // 0: 125 kHz (default), 1: 250 kHz, 2: 500 kHz
+ datarate : 7 // spreading factor, 7(default)..12  
+ coderate : 1 // [1: 4/5 (default), 2: 4/6, 3: 4/7, 4: 4/8]
+ preambleLen : int // peramble length, default: 8
  fixLen : bool // fixed length? a boolean. If true, payloadLen needs specifying too
  crcOn : bool // CRC enabled?
  freqHopOn : bool // frequency hopping on? If true, hopPeriod should be set
  iqInverted : bool // Inverts IQ signals
  rxContinuous : bool // continuous reception? it's easiest to set this to true and manually cancel reception
  symbTimeout : int // RxSingle timeout value when rxContinuous = false
+ forcePaBoost : bool // Required for HopeRF RFM9xW and TTGO LoRa32 modules
 };
 ```
 
@@ -91,6 +93,13 @@ sx.send("Hello", function() {
 });
 ```
 
+Note about Hope RF RFM95W and TTGO LoRa32 modules and transmit power
+--------------------------------------------------------------------
+
+To transmit with these modules you have to pass `forcePaBoost: true` in the TX configuration.
+The manufacturer didn't connect the low-power "RFO" pins to the antenna output. Therefore the lowest output power available with these modules is +2dBm. If the power is outside the allowed range, the library throws `SX127x-PA_BOOST_PWR_ERR`.
+
+
 Reference
 ---------
  
@@ -107,4 +116,6 @@ Buying
 The SX1276 is available in a variety of different modules, from different places: 
 
 * [inAIR9 from Modtronix](http://modtronix.com/inair9.html)
-* [eBay](http://www.ebay.com/sch/i.html?_nkw=SX1276) - watch out for 'compatible' boards that are not true SX1276!
+* [eBay SX1276](http://www.ebay.com/sch/i.html?_nkw=SX1276) - watch out for 'compatible' boards that are not true SX1276!
+* [eBay RFM95W](http://www.ebay.com/sch/i.html?_nkw=RFM95W)
+* [eBay TTGO LoRa32](http://www.ebay.com/sch/i.html?_nkw=TTGO+LoRa32)


### PR DESCRIPTION
This is kind of complicated: there is a low-power and a high power amplifier on the SX127x chips, but apparently Hope RF and TTGO didn't connect the low-power amplifier's output RFO pins to the antenna output. So if anybody wants to transmit must use the PA_BOOST output to get any RF signal.
Of course this is not documented: Hope RF's datasheet is just a copy-paste of the Semtech datasheet, and there is no datasheet at all for the TTGO module.

The only clue I could find is a [blog post](https://www.disk91.com/2019/technology/lora/hoperf-rfm95-and-arduino-a-low-cost-lorawan-solution/) and comments in RadioHead library's RH_RF95.cpp like this:

        // RFM95/96/97/98 does not have RFO pins connected to anything. Only PA_BOOST
        // pin is connected, so must use PA_BOOST

AFAIK you can't detect what module is connected, to to work around this, added a new optional config parameter: `forcePaBoost`.
Tried to follow the origins of the power register calculation back to the Semtech sample, but looks like that code depended on their test board's pin being pulled to 1 or 0 to determine which board they have. So did the power, power DAC and current limit code from scratch.

On the boards I have tested a couple of TX power settings, and the RSSI did change, so assume it's working.

Caveat: I can't test with "proper" SX127x module like the Modtronix one, because I only have the TTGO and HopeRF modules.

Caveat 2: Checked three libraries, and they all have different lower power limits and different register value calculation on the lower end. No idea if there is a reason for the different limits, or just to keep their code simpler?
 - Semtech says -4dBm is the lowest output power. But if my math works, you can't configure exactly -4dBm. You can set it to -4.2, -3.6, -3.0dBm???
 - [Sandeep Mistry's Arduino lib](https://github.com/sandeepmistry/arduino-LoRa) limits power to 0dBm.
 - [RadioHead 1.98](http://www.airspayce.com/mikem/arduino/RadioHead/) limits power to -1dBm
 - [RadioLib](https://github.com/jgromes/RadioLib/blob/master/src/modules/SX127x/SX1278.cpp) limits to -3dBm. Actually this is the lowest non-fractional value you can set.

Can't test these settings with the HopeRF and TTGO modules because +2dBm is the lower limit using PA_BOOST...