### PR TITLE
Firmware Updates: Activate location in Android 10

### DIFF
--- a/boards/Bangle.js.md
+++ b/boards/Bangle.js.md
@@ -458,17 +458,17 @@ Firmware Updates
   * Release `BTN2`
   * Release `BTN1` a moment later while `====` is going across the screen
   * The watch should now be in Dfu mode
-* Install the Nordic Semiconductor NRF Toolbox App for Android or iOS
-* Download the latest stable distribution zip from the [Espruino site](https://www.espruino.com/Download#banglejs) or the latest bleeding edge nightly build from [here](http://www.espruino.com/binaries/travis/master/).
-* Open the NRF Toolbox app
-* Tap the DFU icon
-* Tap Select File, choose Distribution Packet (ZIP), and choose the ZIP file you downloaded
-* If a Select scope window appears, choose All
-* Tap Select Device and choose the device called `DfuTarg`
-* Now tap Upload and wait
-* It will take around 90 seconds to complete
-* Once complete, long-press `BTN3` to go to the Clock
-* You should still have the original apps you installed
+  * Install the Nordic Semiconductor NRF Toolbox App for Android or iOS
+  * Download the latest stable distribution zip from the [Espruino site](https://www.espruino.com/Download#banglejs) or the latest bleeding edge nightly build from [here](http://www.espruino.com/binaries/travis/master/).
+  * Open the NRF Toolbox app
+  * Tap the DFU icon
+  * Tap Select File, choose Distribution Packet (ZIP), and choose the ZIP file you downloaded
+  * If a Select scope window appears, choose All
+  * Tap Select Device and choose the device called `DfuTarg`
+  * Now tap Upload and wait
+  * It will take around 90 seconds to complete
+  * Once complete, long-press `BTN3` to go to the Clock
+  * You should still have the original apps you installed
 
 
 Troubleshooting

--- a/boards/Bangle.js.md
+++ b/boards/Bangle.js.md
@@ -460,6 +460,7 @@ Firmware Updates
   * The watch should now be in Dfu mode
   * Install the Nordic Semiconductor NRF Toolbox App for Android or iOS
   * Download the latest stable distribution zip from the [Espruino site](https://www.espruino.com/Download#banglejs) or the latest bleeding edge nightly build from [here](http://www.espruino.com/binaries/travis/master/).
+  * In addition to activating the bluetooth, the location of Android 10 has to be activated because of [an issue in current NRF Toolbox app releases](https://devzone.nordicsemi.com/f/nordic-q-a/53938/android-10-need-to-toggle-location-permission-to-see-ble-devices)
   * Open the NRF Toolbox app
   * Tap the DFU icon
   * Tap Select File, choose Distribution Packet (ZIP), and choose the ZIP file you downloaded


### PR DESCRIPTION
I deploy new firmware so rarely to my Bangle.js that I always forget this little detail, so I though someone else could also use this info.

Aligned also the bullets, they seem to be twisted here: https://www.espruino.com/Bangle.js#firmware-updates

(sorry the bad commit message "Firmware Updates: Activate location activation")