### PR TITLE
graphical_menu: add `wrap` option for numerical menu items

### DIFF
--- a/modules/graphical_menu.js
+++ b/modules/graphical_menu.js
@@ -87,8 +87,10 @@ exports.list = function(g, items) {
       if (l.selectEdit) {
         var item = l.selectEdit;
         item.value -= (dir||1)*(item.step||1);
-        if (item.min!==undefined && item.value<item.min) item.value = item.min;
-        if (item.max!==undefined && item.value>item.max) item.value = item.max;
+        if (item.min!==undefined && item.value<item.min)
+          item.value = (item.wrap && item.max!==undefined) ? item.max : item.min;
+        if (item.max!==undefined && item.value>item.max)
+          item.value = (item.wrap && item.min!==undefined) ? item.min : item.max;
         if (item.onchange) item.onchange(item.value);
       } else {
         options.selected = (dir+options.selected)%menuItems.length;

--- a/modules/graphical_menu.md
+++ b/modules/graphical_menu.md
@@ -38,7 +38,7 @@ var mainmenu = {
   },
   "A Number" : {
     value : number,
-    min:0,max:100,step:10,
+    min:0,max:100,step:10,wrap:true,
     onchange : v => { number=v; }
   }
 };
@@ -102,6 +102,7 @@ var menuinfo = {
     value : 42,       // A number or boolean to be changed
     step : 1,         // optional (default 1) - the amount to inc/dec the number
     min / max : ...,  // minimum/maximum values to clamp to
+    wrap : boolean,   // optional - wrap around from minimum to maximum and vise versa
     onchange : function(value) // optional - called when the value changes
     format : function(value) // optional - converts the value to a string to be displayed
   }


### PR DESCRIPTION
If this seems like a good idea, I'd be happy to follow up with PRs for [Espruino](https://github.com/espruino/Espruino)/[BangleApps](https://github.com/espruino/BangleApps), as far as I can tell it should "trickle down" to
- https://github.com/espruino/Espruino/blob/master/libs/js/banglejs/E_showMenu_F18.js
- https://github.com/espruino/Espruino/blob/master/libs/js/banglejs/E_showMenu_F5.js
- https://github.com/espruino/Espruino/blob/master/libs/js/banglejs/E_showMenu_Q3.js
- https://github.com/espruino/BangleApps/blob/master/apps/menusmall/boot.js