### PR TITLE
graphical_menu improvements

### DIFF
--- a/modules/graphical_menu.js
+++ b/modules/graphical_menu.js
@@ -69,7 +69,7 @@ exports.list = function(g, items) {
       if (options.preflip) options.preflip(g,less,idx<menuItems.length);
       if (g.flip) g.flip();
     },
-    select : function(dir) {
+    select : function() {
       var item = items[menuItems[options.selected]];
       if ("function" == typeof item) item(l);
       else if ("object" == typeof item) {
@@ -87,14 +87,11 @@ exports.list = function(g, items) {
       if (l.selectEdit) {
         var item = l.selectEdit;
         item.value -= (dir||1)*(item.step||1);
-        if (item.min!==undefined && item.value<item.min)
-          item.value = (item.wrap && item.max!==undefined) ? item.max : item.min;
-        if (item.max!==undefined && item.value>item.max)
-          item.value = (item.wrap && item.min!==undefined) ? item.min : item.max;
+        if (item.min!==undefined && item.value<item.min) item.value = item.wrap ? item.max : item.min;
+        if (item.max!==undefined && item.value>item.max) item.value = item.wrap ? item.min : item.max;
         if (item.onchange) item.onchange(item.value);
       } else {
-        options.selected = (dir+options.selected)%menuItems.length;
-        if (options.selected<0) options.selected += menuItems.length;
+        options.selected = (dir+options.selected+menuItems.length)%menuItems.length;
       }
       l.draw();
     }


### PR DESCRIPTION
- remove unused parameter from `select()`
- shave a few bytes off `move()`

If a numerical item has `item.wrap` we no longer check if `item.min/max` is set, because your menu will be broken either way.