### PR TITLE
Bangle.getOptions ref to setOptions

### DIFF
--- a/bin/espruino.json
+++ b/bin/espruino.json
@@ -2859,8 +2859,8 @@
     },
     "getOptions": {
       "!type": "fn() -> ?",
-      "!doc": "<p>Return the current state of options as set by <code>Bangle.getOptions</code></p>\n",
-      "!url": "http://www.espruino.com/Reference#l_Bangle_getOptions"
+      "!doc": "<p>Return the current state of options as set by <code>Bangle.setOptions</code></p>\n",
+      "!url": "http://www.espruino.com/Reference#l_Bangle_setOptions"
     },
     "isLCDOn": {
       "!type": "fn() -> bool",


### PR DESCRIPTION
Bangle.getOptions currently refer to itsself
I'll continously try to correct the docs when I discover typos etc.