### PR TITLE
Use sleep/wakeup commands for PMS7003 sensor

### DIFF
--- a/devices/PMS7003.md
+++ b/devices/PMS7003.md
@@ -8,7 +8,7 @@ PMS7003 Particulate matter sensor
 
 A minimal driver for the Plantower PMS 7003 particulate matter sensor with [[Serial]] output. Might work with Plantower PMS5003 that uses the same protocol, but not tested. Use the [[PMS7003.js]] module for it.
 
-Here is an english translation of the [Datasheet](/datasheets/PMS7003.pdf).
+Here is an English translation of the [Datasheet](/datasheets/PMS7003.pdf).
 
 
 For minimal configuration, you only need to provide power (5V) to the PMS sensor, and it automatically sends measurements. Hook up it's TX pin to an Espruino's serial RX pin and you are good to go!
@@ -37,7 +37,7 @@ The fan in the sensor uses 5 volt, but all of it's communication lines are 3.3v.
 | 10 (Set)    | -              |
 
 You can leave all other pins unconnected, they have internal pull-ups.
-The sensor automaticallly starts sending data, I measured a varying power consumption between 25-50mA.
+The sensor automatically starts sending data, I measured a varying power consumption between 25-50mA.
 
 
 ## Connect via seller supplied cable
@@ -56,7 +56,7 @@ function onPms(d) {
         console.log('PMS data: ', d);
     } else {
         // Checksum error, discard it
-        console.log('PMS chekcksum ERR!');
+        console.log('PMS checksum ERR!');
     }
 }
 
@@ -127,7 +127,7 @@ You can toggle this with setting `pms.details` to `true` or `false`.
 
 # Power consumption & power down modes
 
-You can use the `5 (Reset)` or the `10 (Set)` pin to power down the sensor to save energy and the lifetime of the fan and laser diode in the sensor.
+You can use the `pms.sleep()` command to power down the sensor to save energy and the lifetime of the fan and laser diode in the sensor. For this to work you will need to connect the RX pin 7 to your serial TX pin. To wake the sensor up again, use `pms.wakeup()`.
 
 
 | Device Pin  | Espruino                       |
@@ -136,28 +136,22 @@ You can use the `5 (Reset)` or the `10 (Set)` pin to power down the sensor to sa
 |  2 (5V)     | 5V                             |
 |  3 (GND)    | GND                            |
 |  4 (GND)    | GND                            |
-|  5 (Reset)  | Optional, any GPIO or n/c      |
+|  5 (Reset)  | -                              |
 |  6 (N/C)    | -                              |
-|  7 (RX)     | -                              |
+|  7 (RX)     | Optional, Serial TX pin        |
 |  8 (N/C)    | -                              |
 |  9 (TX)     | Serial RX pin                  |
-| 10 (Set)    | Optional, any GPIO or n/c      |
+| 10 (Set)    | -                              |
 
 Measured currents on my unit:
 
 | Mode        | Measured power |
 |-------------|----------------|
 | "On"        | 25 - 50 mA     |
-| "Set" low   | 5 mA           |
-| "Reset" low | 1 mA           |
-| Both low    | 1.3 mA         |
 
 The "On" current varies in each 800-900ms cycle, but don't have the equipment to measure the average current.
 
-In my tests neither pulling the "Set" or "Reset" pin is low-power enough, so it's probably better to just cut power to the sensor, if you want to save power. The sensor just start sending data again after 2-3 seconds. Probably you should discard the first couple of measurements after power-on.
-
-# UART control
-Theoretically you can control the module via UART, but couldn't find enough info.
+If sleep mode is not low-power enough, it's probably better to just cut power to the sensor if you want to save power. You can do this using a 5V boost converter with "true shutdown". The sensor just start sending data again after 2-3 seconds. Probably you should discard the first couple of measurements after power-on.
 
 Reference
 ---------


### PR DESCRIPTION
Newer releases of the PMS7003 sensor don't power down when the RESET or SET pins are pulled low, so we have to use the sleep/wakeup commands if we want to save energy.

I've removed the references to the RESET and SET pins are they're not relevant anymore, and replaced it with the sleep/wakeup commands.