### PR TITLE
Font Converter: Attempt to add heatshrink compression

### DIFF
--- a/info/Font Converter.md
+++ b/info/Font Converter.md
@@ -229,16 +229,18 @@ function createFont(fontName, fontHeight, BPP, charMin, charMax) {
 
   var encodedFont;
   if (document.getElementById("useHeatshrink").checked) {
+    const fontArray = new Uint8Array(fontData);
+    const compressedFont = String.fromCharCode.apply(null, heatshrink.compress(fontArray));
     encodedFont = 
-      "require('heatshrink').decompress(atob('" +
-      btoa(heatshrink.compress(new Uint8Array(fontData))) +
-      "'))";
+      "E.toString(require('heatshrink').decompress(atob('" +
+      btoa(compressedFont) +
+      "')))";
   } else {
     encodedFont = "atob('" + btoa(String.fromCharCode.apply(null, fontData)) + "')";
   }
   var result = document.getElementById("result");
   result.style.display = "inherit";
-  result.innerHTML = `
+  result.value = `
 Graphics.prototype.setFont${fontName.replace(/[^A-Za-z0-9]/g,"")} = function(scale) {
   // Actual height ${maxY+1-minY} (${maxY} - ${minY})
   this.setFontCustom(

--- a/info/Font Converter.md
+++ b/info/Font Converter.md
@@ -232,7 +232,7 @@ function createFont(fontName, fontHeight, BPP, charMin, charMax) {
     encodedFont = 
       "require('heatshrink').decompress(atob('" +
       btoa(heatshrink.compress(new Uint8Array(fontData))) +
-      "')";
+      "'))";
   } else {
     encodedFont = "atob('" + btoa(String.fromCharCode.apply(null, fontData)) + "')";
   }

--- a/info/Font Converter.md
+++ b/info/Font Converter.md
@@ -231,7 +231,7 @@ function createFont(fontName, fontHeight, BPP, charMin, charMax) {
   if (document.getElementById("useHeatshrink").checked) {
     encodedFont = 
       "require('heatshrink').decompress(atob('" +
-      btoa(heatshrink.compress(String.fromCharCode.apply(null, fontData))) +
+      btoa(heatshrink.compress(new Uint8Array(fontData))) +
       "')";
   } else {
     encodedFont = "atob('" + btoa(String.fromCharCode.apply(null, fontData)) + "')";


### PR DESCRIPTION
This attempts to add compression with Heatshrink as an option to the font converter. Check the diff.
Tested for me and works. A broken preview is [available](https://ktibow.github.io/EspruinoDocs/info/Font%20Converter) as long as you paste in the contents of https://www.espruino.com/js/heatshrink.js into the console first.