### PR TITLE
Adds support for the MAX17048 and MAX17049 fuel gauges

### DIFF
--- a/devices/MAX1704x.js
+++ b/devices/MAX1704x.js
@@ -22,24 +22,24 @@ MAX1704X.prototype.reset = function() {
 
 MAX1704X.prototype.readRegister = function(register) {
   this.i2c.writeTo({address: 0x36, stop: false}, [register]);
-  var d = new DataView(this.i2c.readFrom(0x36, 3).buffer);
-  return d.getUint16(0);
+  return new DataView(this.i2c.readFrom(0x36, 3).buffer);
 };
 
+
 MAX1704X.prototype.readICVersion = function() {
-  return this.readRegister(0x08).toString(16);
+  return this.readRegister(0x08).getUint16().toString(16);
 };
 
 MAX1704X.prototype.readPercent = function() {
-  return this.readRegister(0x04) / 256.0;
+  return this.readRegister(0x04).getUint16() / 256.0;
 };
 
 MAX1704X.prototype.readVoltage = function(callback) {
-  return this.readRegister(0x02) * 78.125 / 1000000;
+  return this.readRegister(0x02).getUint16() * 78.125 / 1000000;
 };
 
 MAX1704X.prototype.readChargeRate = function(callback) {
-  return this.readRegister(0x16) * 0.208;
+  return this.readRegister(0x16).getInt16() * 0.208;
 };
 
 exports.connect = function (_i2c) {

--- a/devices/MAX1704x.js
+++ b/devices/MAX1704x.js
@@ -1,0 +1,47 @@
+/* Copyright (c) 2022 Gerrit Niezen. See the file LICENSE for copying permission. */
+/*
+Module for the MAX1704x Battery Fuel Gauge ICs
+*/
+
+function MAX1704X(_i2c) {
+  this.i2c = _i2c;
+}
+
+MAX1704X.prototype.reset = function() {
+  try {
+    this.i2c.writeTo(0x36, [0xFE, 0x54, 0x00]);
+  } catch (err) {
+    if (err.message.includes('33282')) {
+      // we got a NACK, which is what we want
+      return;
+    } else {
+      throw new Error('Something went wrong during reset()');
+    }
+  }
+};
+
+MAX1704X.prototype.readRegister = function(register) {
+  this.i2c.writeTo({address: 0x36, stop: false}, [register]);
+  var d = new DataView(this.i2c.readFrom(0x36, 3).buffer);
+  return d.getUint16(0);
+};
+
+MAX1704X.prototype.readICVersion = function() {
+  return this.readRegister(0x08).toString(16);
+};
+
+MAX1704X.prototype.readPercent = function() {
+  return this.readRegister(0x04) / 256.0;
+};
+
+MAX1704X.prototype.readVoltage = function(callback) {
+  return this.readRegister(0x02) * 78.125 / 1000000;
+};
+
+MAX1704X.prototype.readChargeRate = function(callback) {
+  return this.readRegister(0x16) * 0.208;
+};
+
+exports.connect = function (_i2c) {
+  return new MAX1704X(_i2c);
+};

--- a/devices/MAX1704x.md
+++ b/devices/MAX1704x.md
@@ -13,7 +13,7 @@ var fuelGauge = require("MAX1704x").connect(I2C1);
 console.log(`IC Version: 0x${fuelGauge.readICVersion()}`);
 console.log(`Battery percent: ${fuelGauge.readPercent()} %`);
 console.log(`Battery voltage: ${fuelGauge.readVoltage()} V`);
-console.log(`Battery voltage: ${fuelGauge.readChargeRate()} %/hr`);
+console.log(`Battery charge rate: ${fuelGauge.readChargeRate()} %/hr`);
 ```
 
 Reference

--- a/devices/MAX1704x.md
+++ b/devices/MAX1704x.md
@@ -1,0 +1,28 @@
+<!--- Copyright (c) 2022 Gerrit Niezen. See the file LICENSE for copying permission. -->
+MAX1704x Battery Fuel Gauge 
+===========================
+
+* KEYWORDS: Module,I2C,MAX1704x,MAX17048,MAX17049,maxim,ModelGauge,lithium-ion
+
+Use the [MAX1704x](/modules/MAX1704x.js) ([About Modules](/Modules)) module to track Li+ battery relative state-of-charge with MAX17048/MAX17049 fuel gauge chips.
+Basic usage:
+
+```
+I2C1.setup({scl:D6,sda:D7});
+var fuelGauge = require("MAX1704x").connect(I2C1);
+console.log(`IC Version: 0x${fuelGauge.readICVersion()}`);
+console.log(`Battery percent: ${fuelGauge.readPercent()} %`);
+console.log(`Battery voltage: ${fuelGauge.readVoltage()} V`);
+console.log(`Battery voltage: ${fuelGauge.readChargeRate()} %/hr`);
+```
+
+Reference
+--------------
+
+* APPEND_JSDOC: MAX1740x.js
+
+
+Using
+-----
+
+* APPEND_USES: MAX1740X


### PR DESCRIPTION
Adds support for the MAX1704x fuel gauges, as used in the [Adafruit MAX17048 LiPoly / LiIon Fuel Gauge and Battery Monitor](https://www.adafruit.com/product/5580).