### PR TITLE
Update BLE compatibility of the ESP32, remove NBSP, fix table formatting

### DIFF
--- a/boards/ESP32.md
+++ b/boards/ESP32.md
@@ -4,7 +4,7 @@ Espruino on ESP32
 
 <span style="color:red">:warning: **Please view the correctly rendered version of this page at https://www.espruino.com/ESP32. Links, lists, videos, search, and other features will not work correctly when viewed on GitHub** :warning:</span>
 
-* KEYWORDS: ESP32,Espruino,Board,PCB,Pinout,Internet,WiFi,Wireless,Radio
+* KEYWORDS: ESP32,Espruino,Board,PCB,Pinout,Internet,WiFi,Wireless,Radio,Bluetooth,BLE,Bluetooth LE
 
 **Note:** *This page documents running the Espruino firmware on the ESP32 board.
 
@@ -20,7 +20,7 @@ Contents
 
 The [ESP32](https://espressif.com/en/products/hardware/esp32/overview) is a dual core Tensilica LX6
 microcontroller with 520 KB SRAM, integrated Wifi, Bluetooth, and more.  [Espruino](https://github.com/espruino/Espruino)
-is a very light weight JavaScript interpreter that runs on the ESP32, and other microcontrollers.
+is a very lightweight JavaScript interpreter that runs on the ESP32, and other microcontrollers.
 
 This documentation is intended for those who want to run JavaScript on any ESP32 microcontrollers.
 It will describe how to flash the ESP32 with the latest firmware, connect to Wifi and get the
@@ -68,15 +68,16 @@ Supported by Espruino on the ESP32:
 * ADC
 * Serial
 * WIFI - as a client and access point
+* Bluetooth LE - BLE
 
 Not supported by Espruino on the ESP32 (yet):
 
 * No Over-The-Air (OTA) firmware updates.
-* Bluetooth and BLE
+* Bluetooth Classic
 
 ### Known Issues
 
-* Espruino Web IDE has issues with the ESP32, see [below](#espruino-web-ide).
+* Espruino Web IDE had issues with the ESP32 back in 2017, see [below](#espruino-web-ide).
 
 ---
 
@@ -224,13 +225,15 @@ Your device is flashed.
 The [Espruino Web IDE](http://www.espruino.com/Web+IDE) is a basic development environment
 that allows you to write your code and deploy it to the ESP32.  
 
-*Issue*: There is an issue with Espruino Web IDE, sometimes it will not connect.
+*Issue*: In 2017, there was an issue with Espruino Web IDE, sometimes it will not connect.
 Especially the first time you try.  The workaround is to use another tool to
 connect to the ESP32, like minicom or cutecom, see below.  Once connected using one of these tools, try again using Espruino Web IDE.
 
 Once you have connected once and enabled wifi on boot (see below), you will be
 able to connect to the ESP32 via telnet, using Espruino Web IDE, this tends to
 be quite reliable.
+
+If these instructions were still relevant for you in 2022 or later, please edit the docs to reflect that it's an ongoing issue.
 
 #### minicom / CuteCom
 
@@ -339,7 +342,7 @@ This will output something like `Web server running at http://10.42.0.119` and y
 
 ### Bluetooth
 
-Not yet implemented
+See [https://www.espruino.com/BLE+Communications](https://www.espruino.com/BLE+Communications)
 
 ## GPIO Pins
 
@@ -472,7 +475,7 @@ Please have in mind, PWM via analog always need a lowpass filter, usually a simp
 ### Analog Read / Write Example
 
 There are two ADC channels but only ADC-1 is support at the moment. The ADC-1 channel is accessible through `IO35` and `IO36`(`VP_SENSOR`).
-ADC PINs shouldn't not be connected to a voltage higher than VCC - if a higher input voltage is needed, a resistor should be added between the input and the ADC and then the real voltage could be calculated by including the resistor's voltage drop in the equation.
+ADC PINs should not be connected to a voltage higher than VCC - if a higher input voltage is needed, a resistor should be added between the input and the ADC and then the real voltage could be calculated by including the resistor's voltage drop in the equation.
 
 usage example: reading analog voltage from IO35
 
@@ -532,17 +535,16 @@ Current ESP32 modules are 4Mb.
 
 The result of all this is the following:
 
-Start    | Length | Function
---------:|-------:|:----------------------------------------
-0x000000 |    4KB | Secure Boot
-0x008000 |    4KB | Bootloader
-0x009000 |   16KB | nvs - esp-idf non-volatile storage area
-0x00d000 |    8KB | otadata - esp-idf keeps track on which the current firmware to boot
-0x010000 |  960KB | factory - the initial espruino firmware.
-0x100000 |   64KB | js_code - the saved espruino interpreter and `E.setBootCode()`
-0x200000 | 1024KB | ota_0 - area for ota updates (not yet implemented)
-0x300000 | 1024KB | 1Mb Flash Fat Filesystem
-
+|    Start | Length | Function                                                            |
+|---------:|-------:|:--------------------------------------------------------------------|
+| 0x000000 |    4KB | Secure Boot                                                         |
+| 0x008000 |    4KB | Bootloader                                                          |
+| 0x009000 |   16KB | nvs - esp-idf non-volatile storage area                             |
+| 0x00d000 |    8KB | otadata - esp-idf keeps track on which the current firmware to boot |
+| 0x010000 |  960KB | factory - the initial espruino firmware.                            |
+| 0x100000 |   64KB | js_code - the saved espruino interpreter and `E.setBootCode()`      |
+| 0x200000 | 1024KB | ota_0 - area for ota updates (not yet implemented)                  |
+| 0x300000 | 1024KB | 1Mb Flash Fat Filesystem                                            |
 
 This is defined in partitions_espruino.csv in the EspruinoBuildTools repository
 

--- a/boards/Other Boards.md
+++ b/boards/Other Boards.md
@@ -6,7 +6,7 @@ Other Boards
 
 * KEYWORDS: Nucleo,Discovery,Maple,Olimexino,Leaflabs,Arduino
 
-These are other boards that Espruino compiles for, but which aren't 'officially supported'. This means:
+These are other boards that Espruino compiles for, but which aren't 'officially supported'. This means:
 
 *   Espruino does not come pre-installed on the board
 *   Your purchase does not help to support the Espruino project
@@ -14,10 +14,10 @@ These are other boards that Espruino compiles for, but which aren't 'officially 
 *   The modules, tutorials and examples are designed for the Espruino Board and may not work
 *   The Web IDE may have to employ 'throttling' for error free communications - significantly slowing down your experience.
 *   You cannot update the firmware for other boards via the Web IDE
-*   We're not able to support you if you have problems using these boards. If you want support, get an [official board](/Order)
+*   We're not able to support you if you have problems using these boards. If you want support, get an [official board](/Order)
 *   The community is responsible for maintaining these boards, and as such releases are not subject to the same level of testing.
 
-**Note:** ST Nucleo and Discovery boards are sold at a low price, for evaluation purposes only. According to the [Evaluation products license agreement](http://www.st.com/st-web-ui/static/active/en/resource/legal/legal_agreement/license_agreement/EvaluationProductLicenseAgreement.pdf) that comes with each board, you must **not use them as part of a finished product**. If you want to do that, please check out our [official boards](/Order).
+**Note:** ST Nucleo and Discovery boards are sold at a low price, for evaluation purposes only. According to the [Evaluation products license agreement](http://www.st.com/st-web-ui/static/active/en/resource/legal/legal_agreement/license_agreement/EvaluationProductLicenseAgreement.pdf) that comes with each board, you must **not use them as part of a finished product**. If you want to do that, please check out our [official boards](/Order).
 
 To see how to get started with the [official boards](/Order), just follow our [Quick Start](/Quick+Start) guide, or you can [Order one here](/Order).
 
@@ -28,41 +28,41 @@ Contents
 
 ## Boards that Espruino works on
 
- |      | **Chip** | **Speed**<br>MHz | **Vars** | **Cost** | **USB** | **UART** | **SPI** | **Bat** | **Other** |
- |------|----------|-----------|----------|----------|---------|-----------|----------|---------|-----------|
-  | **Official Boards** |  |  |  |  |  |  |  |  |  |
- | [**Espruino Original**](/Original) | STM32F104 | 72 | 2200 | £21 | Y | 3 | 2 | Y | Micro SD, Optional Bluetooth Serial, Proto area |
- | [**Espruino Pico**](/Pico) | STM32F401 | 84 | 5100 | £17 | Y | 3 | 2 | Y |  |
- | [**Espruino WiFi**](/WiFi) | STM32F411 | 100 | 7100 | -- | Y | 3 | 2 | N |  WiFi |
- | [**Espruino Puck.js**](/Puck.js) | nRF52832 | 64 | 2200 | £25 | N | 1 | 1 | Y |  Bluetooth LE, Case with Button, Accelerometer, Gyro, Magnetometer, Temperature |
- | [**Espruino Pixl.js**](/Pixl.js) | nRF52832 | 64 | 2200 | £30 | N | 1 | 1 | Y |  LCD Display, Arduino Headers, Bluetooth LE |
- | [**Espruino Bangle.js**](/Bangle.js) | nRF52832 | 64 | 2200 | -- | N | - | - | Y | LCD Display, Bluetooth LE, Vibration, Accelerometer |
- | [**Espruino Bangle.js 2**](/Bangle.js2) | nRF52840 | 64 | 12000 | £64 | N | - | - | Y | LCD Display, Bluetooth LE, Vibration, Accelerometer |
- | [**Espruino MDBT42Q Breakout**](/MDBT42Q) | nRF52832 | 64 | 2200 | £17 | N | 1 | 1 | N | Bluetooth LE |
- | [**Espruino MDBT42Q Module**](/MDBT42Q) | nRF52832 | 64 | 2200 | £10 | N | 1 | 1 | N | Bluetooth LE, Bare Module |
- | **Third Party Boards** |  |  |  |  |  |  |  |  |  |
- | [**Ruuvitag**](/Ruuvitag) | nRF52832 | 64 | 2000 | $28 | N | 1 | 1 | Y | Bluetooth LE, Environment sensors |
- | [**Seeed Wio LTE**](/WioLTE) | STM32F405 | 168 | 5450 | $25 | Y | 6 | 3 | Y | Micro SD, LTE |
- | [**Nordic Thingy:52**](/Thingy52) | nRF52832 | 64 | 2000 | $40 | N | 1 | 1 | Y | Environment & 9 Axis sensors, Mic and Speaker |
- | [**nRF52832DK DK**](/nRF52832DK) | nRF52832 | 64 | 2000 | $40 | N | 1 | 1 | Y | Arduino Headers |
- | [**STM32L496GDISCOVERY**](/STM32L496GDISCOVERY) | STM32L496AGI6 | 168 | 19200 | $70 | Y | 3 | 4 | N | Arduino Headers, Micro SD, Optional LTE/GSM modules |
- | [**iTracker RAK8211**](/RAK8211) | nRF52832 | 64 | 2000 | $82 | N | 1 | 1 | Y | GPS, GPRS, LTE or NB-IoT |
- | [**iTracker RAK8212**](/RAK8212) | nRF52832 | 64 | 2000 | $88 | N | 1 | 1 | Y | GPS, GPRS, LTE, NB-IoT |
- | **Other Boards** |  |  |  |  |  |  |  |  |  |
- | [**STM32VLDISCOVERY**](/ReferenceSTM32VLDISCOVERY) | STM32F100 | 24 | 250 | €12 | N | 3 | 2 | N | |
- | [**STM32F3DISCOVERY**](/ReferenceSTM32F3DISCOVERY) | STM32F303 | 72 | 2800 | €14 | Y | 3 | 2 | N | |
- | [**STM32F4DISCOVERY**](/ReferenceSTM32F4DISCOVERY) | STM32F407 | 168 | 5000 | €16 | Y | 6 | 3 | N | |
- | [**ST NUCLEO-F401RE**](/ReferenceNUCLEOF401RE) | STM32F401 | 84 | 5300 | €12 | N | 3 | 4 | N | Arduino Headers |
- | [**ST NUCLEO-F411RE**](/ReferenceNUCLEOF411RE) | STM32F411 | 84 | 5300 | €12 | N | 3 | 4 | N | Arduino Headers |
- | [**OLIMEXINO-STM32**](/ReferenceOLIMEXINO_STM32) | STM32F103RB | 72 | 700 | €20 | Y | 3 | 2 | LiPo | Arduino Headers, Micro SD |
- | [**LeafLabs Maple RBT6**](/ReferenceOLIMEXINO_STM32) | STM32F103RB | 72 | 700 | €40 | Y | 3 | 2 | LiPo | Arduino Headers |
- | [**'HY' 2.4" LCD **](/ReferenceHYSTM32_24) | STM32F103VE | 72 | 2800 | €30 | Y | 3 | 2 | N | SD Card, LCD Display |
- | [**'HY' 2.8" LCD**](/ReferenceHYSTM32_28) | STM32F103RB | 72 | 700 | €30 | Y | 3 | 2 | N | SD Card (unsupported),LCD Display |
- | [**'HY' 3.2" LCD**](/ReferenceHYSTM32_32) | STM32F103VC | 72 | 2000 | €30 | Y | 3 | 2 | N | SD Card, LCD Display |
- | [**micro:bit**](/MicroBit) | nRF51822 | 16 | 200 | - | Y | 1 | 1 | Y | Bluetooth LE, LED matrix |
- | [**micro:bit 2**](/MicroBit) | nRF52833 | 64 | 6000 | - | Y | 1 | 1 | Y | Bluetooth LE, LED matrix, Speaker, Mic |
- | [**ESP8266**](/EspruinoESP8266) | Xtensa | 80 | 1023 | €10 | N | 1 | 1 | N | WiFi |
- | [**ESP32**](/ESP32) | Xtensa | 240 | 5000 | $10 | N | 2 | 2 | N | Flash FS, WiFi |
+|                                                      | **Chip**      | **Speed**<br>MHz | **Vars** | **Cost** | **USB** | **UART** | **SPI** | **Bat** | **Other**                                                                      |
+|------------------------------------------------------|---------------|------------------|----------|----------|---------|----------|---------|---------|--------------------------------------------------------------------------------|
+| **Official Boards**                                  |               |                  |          |          |         |          |         |         |                                                                                |
+| [**Espruino Original**](/Original)                   | STM32F104     | 72               | 2200     | £21      | Y       | 3        | 2       | Y       | Micro SD, Optional Bluetooth Serial, Proto area                                |
+| [**Espruino Pico**](/Pico)                           | STM32F401     | 84               | 5100     | £17      | Y       | 3        | 2       | Y       |                                                                                |
+| [**Espruino WiFi**](/WiFi)                           | STM32F411     | 100              | 7100     | --       | Y       | 3        | 2       | N       | WiFi                                                                           |
+| [**Espruino Puck.js**](/Puck.js)                     | nRF52832      | 64               | 2200     | £25      | N       | 1        | 1       | Y       | Bluetooth LE, Case with Button, Accelerometer, Gyro, Magnetometer, Temperature |
+| [**Espruino Pixl.js**](/Pixl.js)                     | nRF52832      | 64               | 2200     | £30      | N       | 1        | 1       | Y       | LCD Display, Arduino Headers, Bluetooth LE                                     |
+| [**Espruino Bangle.js**](/Bangle.js)                 | nRF52832      | 64               | 2200     | --       | N       | -        | -       | Y       | LCD Display, Bluetooth LE, Vibration, Accelerometer                            |
+| [**Espruino Bangle.js 2**](/Bangle.js2)              | nRF52840      | 64               | 12000    | £64      | N       | -        | -       | Y       | LCD Display, Bluetooth LE, Vibration, Accelerometer                            |
+| [**Espruino MDBT42Q Breakout**](/MDBT42Q)            | nRF52832      | 64               | 2200     | £17      | N       | 1        | 1       | N       | Bluetooth LE                                                                   |
+| [**Espruino MDBT42Q Module**](/MDBT42Q)              | nRF52832      | 64               | 2200     | £10      | N       | 1        | 1       | N       | Bluetooth LE, Bare Module                                                      |
+| **Third Party Boards**                               |               |                  |          |          |         |          |         |         |                                                                                |
+| [**Ruuvitag**](/Ruuvitag)                            | nRF52832      | 64               | 2000     | $28      | N       | 1        | 1       | Y       | Bluetooth LE, Environment sensors                                              |
+| [**Seeed Wio LTE**](/WioLTE)                         | STM32F405     | 168              | 5450     | $25      | Y       | 6        | 3       | Y       | Micro SD, LTE                                                                  |
+| [**Nordic Thingy:52**](/Thingy52)                    | nRF52832      | 64               | 2000     | $40      | N       | 1        | 1       | Y       | Environment & 9 Axis sensors, Mic and Speaker                                  |
+| [**nRF52832DK DK**](/nRF52832DK)                     | nRF52832      | 64               | 2000     | $40      | N       | 1        | 1       | Y       | Arduino Headers                                                                |
+| [**STM32L496GDISCOVERY**](/STM32L496GDISCOVERY)      | STM32L496AGI6 | 168              | 19200    | $70      | Y       | 3        | 4       | N       | Arduino Headers, Micro SD, Optional LTE/GSM modules                            |
+| [**iTracker RAK8211**](/RAK8211)                     | nRF52832      | 64               | 2000     | $82      | N       | 1        | 1       | Y       | GPS, GPRS, LTE or NB-IoT                                                       |
+| [**iTracker RAK8212**](/RAK8212)                     | nRF52832      | 64               | 2000     | $88      | N       | 1        | 1       | Y       | GPS, GPRS, LTE, NB-IoT                                                         |
+| **Other Boards**                                     |               |                  |          |          |         |          |         |         |                                                                                |
+| [**STM32VLDISCOVERY**](/ReferenceSTM32VLDISCOVERY)   | STM32F100     | 24               | 250      | €12      | N       | 3        | 2       | N       |                                                                                |
+| [**STM32F3DISCOVERY**](/ReferenceSTM32F3DISCOVERY)   | STM32F303     | 72               | 2800     | €14      | Y       | 3        | 2       | N       |                                                                                |
+| [**STM32F4DISCOVERY**](/ReferenceSTM32F4DISCOVERY)   | STM32F407     | 168              | 5000     | €16      | Y       | 6        | 3       | N       |                                                                                |
+| [**ST NUCLEO-F401RE**](/ReferenceNUCLEOF401RE)       | STM32F401     | 84               | 5300     | €12      | N       | 3        | 4       | N       | Arduino Headers                                                                |
+| [**ST NUCLEO-F411RE**](/ReferenceNUCLEOF411RE)       | STM32F411     | 84               | 5300     | €12      | N       | 3        | 4       | N       | Arduino Headers                                                                |
+| [**OLIMEXINO-STM32**](/ReferenceOLIMEXINO_STM32)     | STM32F103RB   | 72               | 700      | €20      | Y       | 3        | 2       | LiPo    | Arduino Headers, Micro SD                                                      |
+| [**LeafLabs Maple RBT6**](/ReferenceOLIMEXINO_STM32) | STM32F103RB   | 72               | 700      | €40      | Y       | 3        | 2       | LiPo    | Arduino Headers                                                                |
+| [**'HY' 2.4" LCD**](/ReferenceHYSTM32_24)            | STM32F103VE   | 72               | 2800     | €30      | Y       | 3        | 2       | N       | SD Card, LCD Display                                                           |
+| [**'HY' 2.8" LCD**](/ReferenceHYSTM32_28)            | STM32F103RB   | 72               | 700      | €30      | Y       | 3        | 2       | N       | SD Card (unsupported),LCD Display                                              |
+| [**'HY' 3.2" LCD**](/ReferenceHYSTM32_32)            | STM32F103VC   | 72               | 2000     | €30      | Y       | 3        | 2       | N       | SD Card, LCD Display                                                           |
+| [**micro:bit**](/MicroBit)                           | nRF51822      | 16               | 200      | -        | Y       | 1        | 1       | Y       | Bluetooth LE, LED matrix                                                       |
+| [**micro:bit 2**](/MicroBit)                         | nRF52833      | 64               | 6000     | -        | Y       | 1        | 1       | Y       | Bluetooth LE, LED matrix, Speaker, Mic                                         |
+| [**ESP8266**](/EspruinoESP8266)                      | Xtensa        | 80               | 1023     | €10      | N       | 1        | 1       | N       | WiFi                                                                           |
+| [**ESP32**](/ESP32)                                  | Xtensa        | 240              | 5000     | $10      | N       | 2        | 2       | N       | Bluetooth LE, Flash FS, WiFi                                                   |
 
 **Key:** `Y`=Yes, `N`=No
 
@@ -80,33 +80,33 @@ Good value, and can usually be purchased from well-known suppliers. It contains 
 
 It comes pre-flashed with a bootloader. HOWEVER there is not enough space for this and Espruino, so you will need to overwrite it using a USB-TTL converter. See [Serial Bootloader](/Serial+Bootloader) for instructions.
 
-You can get this directly from [Olimex](https://www.olimex.com/Products/Duino/STM32/OLIMEXINO-STM32/) or [Farnell/Element14](http://uk.farnell.com/olimex/olimexino-stm32/board-dev-olimexino-stm32/dp/2061325).
+You can get this directly from [Olimex](https://www.olimex.com/Products/Duino/STM32/OLIMEXINO-STM32/) or [Farnell/Element14](http://uk.farnell.com/olimex/olimexino-stm32/board-dev-olimexino-stm32/dp/2061325).
 
 ### 'HY' LCD Modules
 
-These appear to come from [Haoyu](http://www.hotmcu.com/) electronics and come in a few types, with varying LCD sizes. They are amazingly good value, and can be obtained from eBay (although they are often shipped direct from Hong Kong or China). They don't generally have a specific name or model number, so are hard to tell apart.
+These appear to come from [Haoyu](http://www.hotmcu.com/) electronics and come in a few types, with varying LCD sizes. They are amazingly good value, and can be obtained from eBay (although they are often shipped direct from Hong Kong or China). They don't generally have a specific name or model number, so are hard to tell apart.
 
 Espruino contains bitmap and vector fonts, and along with the SD card driver and space for saving variables Espruino starts to have trouble fitting in just 128kb of Flash - so we suggest that you avoid the RBT6-based board and head for the VET6 or VCT6 ones.
 
-**2.4" STM32F103VET6 **- 512kb Flash, 64kb RAM - The largest board, but with the most features - 4 buttons, 4 LEDs, 2 Potentiometers, 2x USB, an RS232-level serial connection, SD card, buzzer, and a external flash chip. Has 'HY-STM32_100P' on the back of the PCB. **BEWARE: There is a new version of this board that is wired up differently - Espruino will only drive the LCD on the original board.**
+**2.4" STM32F103VET6 **- 512kb Flash, 64kb RAM - The largest board, but with the most features - 4 buttons, 4 LEDs, 2 Potentiometers, 2x USB, an RS232-level serial connection, SD card, buzzer, and a external flash chip. Has 'HY-STM32_100P' on the back of the PCB. **BEWARE: There is a new version of this board that is wired up differently - Espruino will only drive the LCD on the original board.**
 
-**2.8" STM32F103VET6** - 256kb Flash, 48kb RAM - This looks just like the 2.4" STM32F103VET6, but is **UNTESTED** (May work with 2.4" drivers)
+**2.8" STM32F103VET6** - 256kb Flash, 48kb RAM - This looks just like the 2.4" STM32F103VET6, but is **UNTESTED** (May work with 2.4" drivers)
 
-**2.8" STM32F103RBT6** - 128kb Flash, 20kb RAM - This works, however the board itself very basic with few peripherals, the CPU does not have much flash memory, and it is not recommended. RBT6 does not support the faster FSMC LCD interface, so LCD updates are slow. SD card is currently unimplemented. Has MINI-STM32-V3.0 on the main board under the LCD.** BEWARE: Boards with an SD card and 'armjishu.com' written on the bottom are currently unsupported.**
+**2.8" STM32F103RBT6** - 128kb Flash, 20kb RAM - This works, however the board itself very basic with few peripherals, the CPU does not have much flash memory, and it is not recommended. RBT6 does not support the faster FSMC LCD interface, so LCD updates are slow. SD card is currently unimplemented. Has MINI-STM32-V3.0 on the main board under the LCD.** BEWARE: Boards with an SD card and 'armjishu.com' written on the bottom are currently unsupported.**
 
-**3.2" STM32F103VCT6** - 256kb Flash, 48kb RAM - Works well. It has a big display and it is quite fast. Few on-board peripherals though (2 LEDs, 2 Buttons and an SD card). Recommended.
+**3.2" STM32F103VCT6** - 256kb Flash, 48kb RAM - Works well. It has a big display and it is quite fast. Few on-board peripherals though (2 LEDs, 2 Buttons and an SD card). Recommended.
 
-**3.2" STM32F103RBT6** - 128kb Flash, 20kb RAM - **UNTESTED **(May work with 2.8" drivers)
+**3.2" STM32F103RBT6** - 128kb Flash, 20kb RAM - **UNTESTED **(May work with 2.8" drivers)
 
 ## Wiring up a serial port
 
-Every supported board except the STM32VLDISCOVERY has a USB serial port, so most users can skip this step. If you have an STM32VLDISCOVERY, or you want to use Bluetooth, or to connect to a Raspberry Pi using serial (rather than USB), please see the [Wiring Up](/Wiring+Up) page.
+Every supported board except the STM32VLDISCOVERY has a USB serial port, so most users can skip this step. If you have an STM32VLDISCOVERY, or you want to use Bluetooth, or to connect to a Raspberry Pi using serial (rather than USB), please see the [Wiring Up](/Wiring+Up) page.
 
 ## Plug in Espruino
 
 You communicate with Espruino using a Terminal Emulator over a Serial port. Most Espruino devices can emulate a Serial port over USB, so when you plug these in to your PC or Mac the Operating System will automatically detect them. All you need to do is find out what the Operating System has 'called' the serial port that has been created.
 
-**Windows XP Users:** Windows XP seems not to have generic drivers for USB Virtual COM Ports installed, so you'll have to get them from ST [via this link](http://www.st.com/web/en/catalog/tools/PF257938) (thanks Josef!)
+**Windows XP Users:** Windows XP seems not to have generic drivers for USB Virtual COM Ports installed, so you'll have to get them from ST [via this link](http://www.st.com/web/en/catalog/tools/PF257938) (thanks Josef!)
 
 First off, you need to know which USB port to connect to:
 
@@ -114,9 +114,9 @@ First off, you need to know which USB port to connect to:
 |-------------------|------------------------------------------------|
 | **ESPRUINO & PICO BOARDS** | **There's just one USB port - so it's easy!** |
 | **NUCLEOF4xxRE** | There's just one USB port, which serves as the programmer, serial port, and mass storage device. |
-| **STM32VLDISCOVERY   ** | You will have had to use a USB-TTL converter (see [Wiring Up](/Wiring+Up)). After programming you'll need to connect at 9600 baud. |
-| **STM32F3DISCOVERY   ** | Plug in to the port labelled 'USB USER'. **Note:** This board is more difficult to connect to. You need to power up the board without 'USB USER' plugged in, and then plug in USB later. If you subsequently reset the board, you'll need to unplug USB and plug it back in. |
-| **STM32F4DISCOVERY   ** | Plug in to the port nearest the headphone Jack. Note: This board still needs power from an external source such as the USB port on the other side. |
+| **STM32VLDISCOVERY   ** | You will have had to use a USB-TTL converter (see [Wiring Up](/Wiring+Up)). After programming you'll need to connect at 9600 baud. |
+| **STM32F3DISCOVERY   ** | Plug in to the port labelled 'USB USER'. **Note:** This board is more difficult to connect to. You need to power up the board without 'USB USER' plugged in, and then plug in USB later. If you subsequently reset the board, you'll need to unplug USB and plug it back in. |
+| **STM32F4DISCOVERY   ** | Plug in to the port nearest the headphone Jack. Note: This board still needs power from an external source such as the USB port on the other side. |
 | **'HY' board** | Use either of the two available USB ports. The one nearest the power LED is a built-in USB-TTL converter, and the other is a Virtual COM port. **Note:** We'd suggest using the 'Virtual COM port' USB port as this is faster and shouldn't have flow control problems.|
  | **Olimexino STM32 Leaflabs Maple** | The one USB port |
 
@@ -133,11 +133,11 @@ See the [Download](/Download) page for more information - the Web IDE directly s
 
 *   When you plug your board in, it should appear as a USB flash drive.
 
-*   To actually communicate with Espruino you'll need access to the communications port on the Nucleo, and for that you may need some drivers. ST provides them for Windows [Vista/7/8](http://www.st.com/web/en/catalog/tools/PF260218) and [XP](http://www.st.com/web/en/catalog/tools/PF260219). You may also want to check out ST's [getting started](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105928.pdf) guide.
+*   To actually communicate with Espruino you'll need access to the communications port on the Nucleo, and for that you may need some drivers. ST provides them for Windows [Vista/7/8](http://www.st.com/web/en/catalog/tools/PF260218) and [XP](http://www.st.com/web/en/catalog/tools/PF260219). You may also want to check out ST's [getting started](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105928.pdf) guide.
 
 *   If this is the first time you've used the board then you will probably want to [update your Nucleo's firmware](http://developer.mbed.org/teams/ST/wiki/Nucleo-Firmware). Not doing this could cause problems when you try and upload Espruino (or any software) - especially on Macs.
 
-*   Copy the file espruino_1vXX_nucleof401re.bin out of the ZIP file you got from the download page and paste it into the flash drive
+*   Copy the file espruino_1vXX_nucleof401re.bin out of the ZIP file you got from the download page and paste it into the flash drive
 
 *   Wait until the LEDs have stopped blinking, reset your board, and connect with the Web IDE (at 9600 baud, the default) to start using Espruino.
 
@@ -145,7 +145,7 @@ See the [Download](/Download) page for more information - the Web IDE directly s
 
 ### On Windows
 
-*   Go to the ST-Link website: [http://www.st.com/internet/evalboard/product/251168.jsp](http://www.st.com/internet/evalboard/product/251168.jsp) and click 'Design Support', then download and install the 'STM32 ST-LINK utility'.
+*   Go to the ST-Link website: [http://www.st.com/internet/evalboard/product/251168.jsp](http://www.st.com/internet/evalboard/product/251168.jsp) and click 'Design Support', then download and install the 'STM32 ST-LINK utility'.
 
 *   Extract the archive containing Espruino
 
@@ -176,7 +176,7 @@ See the [Download](/Download) page for more information - the Web IDE directly s
     make
 ```
 
-    Or by using the instructions here: [http://cu.rious.org/make/getting-stlink-to-work-on-mac-os-x-with-macports/](http://cu.rious.org/make/getting-stlink-to-work-on-mac-os-x-with-macports/) however Branton tells us that these are out of date.
+    Or by using the instructions here: [http://cu.rious.org/make/getting-stlink-to-work-on-mac-os-x-with-macports/](http://cu.rious.org/make/getting-stlink-to-work-on-mac-os-x-with-macports/) however Branton tells us that these are out of date.
 
 *   Extract the archive containing Espruino to the stlink directory.
 
@@ -186,7 +186,7 @@ See the [Download](/Download) page for more information - the Web IDE directly s
 
 Unfortunately the USB bootloader pre-installed on these devices takes up too much flash to allow a usable version of Espruino to be installed. This means you'll have to overwrite the USB bootloader. This is pretty simple - you just need a USB-TTL converter. It's also trivial to write the bootloader back in later on.
 
-Just follow our [Serial Bootloader](/Serial+Bootloader) instructions and use the file espruino_1vXX_olimexino_stm32.bin. If you want to restore your board to use the Maple bootloader, just use the binary file available from [http://leaflabs.com/docs/bootloader.html#flashing-a-custom-bootloader](http://leaflabs.com/docs/bootloader.html#flashing-a-custom-bootloader)
+Just follow our [Serial Bootloader](/Serial+Bootloader) instructions and use the file espruino_1vXX_olimexino_stm32.bin. If you want to restore your board to use the Maple bootloader, just use the binary file available from [http://leaflabs.com/docs/bootloader.html#flashing-a-custom-bootloader](http://leaflabs.com/docs/bootloader.html#flashing-a-custom-bootloader)
 
 ### 'HY' LCD Boards
 
@@ -202,9 +202,9 @@ The 'HY' boards have a USB-RS232 converter onboard, so to flash them, you can us
 *   Follow our [Serial Bootloader](/Serial+Bootloader) instructions - use the file `espruino_..._hystm32_XX_YY.bin` where XX is the size of the LCD screen (24=2.4, etc) and YY is the two letters from the chip name after F103 (STM32F103VCT6 = VC)
 *   On the 2.4" board, move the 'BOOT0' jumper back to 0
 *   Press Reset, and Espruino will load.
-*   If connecting to the RS232 converter port of the board, you'll need to connect at 9600 baud.
+*   If connecting to the RS232 converter port of the board, you'll need to connect at 9600 baud.
 
-In order to run the Python file from the link above,  you may need to have Python 2.7 installed, and not the newest version of Python (version 3).
+In order to run the Python file from the link above,  you may need to have Python 2.7 installed, and not the newest version of Python (version 3).
 
 ### Raspberry Pi
 
@@ -214,7 +214,7 @@ The version for Raspberry Pi is a simple executable. Extract it from the ZIP fil
 
 You may also want to rename it:
 
-`mv espruino_1vXX_raspberrypi espruino`
+`mv espruino_1vXX_raspberrypi espruino`
 
 Finally, just run it with:
 
@@ -222,16 +222,16 @@ Finally, just run it with:
 
 Note that in order to use GPIO (or to start an HTTP server with a port number less than 1024), Espruino will need to be run as root:
 
-`sudo ./espruino `
+`sudo ./espruino `
 
 Also, the Raspberry Pi version doesn't currently support Serial, SPI, OneWire or I2C - which means you're stuck with GPIO.
 
 ## Finally...
 
-<font color="red">**Please Note:** If you have saved code to Espruino, when booting it will load your saved JavaScript program from flash memory. Occasionally we change the way programs are stored in memory between versions in order to make Espruino more efficient, and when this happens, after flashing the latest version of Espruino to the device, it may stop booting. You can solve this in two ways:</font>
+<font color="red">**Please Note:** If you have saved code to Espruino, when booting it will load your saved JavaScript program from flash memory. Occasionally we change the way programs are stored in memory between versions in order to make Espruino more efficient, and when this happens, after flashing the latest version of Espruino to the device, it may stop booting. You can solve this in two ways:</font>
 
 *   If you're using the stm32loader.py, you can supply the '-e' flag to completely erase the STM32's flash.
-*   Hold down Button1 while booting (which will stop Espruino automatically loading the saved program)  - see [here](http://www.espruino.com/Reference#l__global_save) for details. You can then type 'save()' to save a correct (but Empty) JavaScript program back into flash.
+*   Hold down Button1 while booting (which will stop Espruino automatically loading the saved program)  - see [here](http://www.espruino.com/Reference#l__global_save) for details. You can then type 'save()' to save a correct (but Empty) JavaScript program back into flash.
 
 See our [Quick Start](/Quick+Start) page for how to get started using Espruino itself.
 


### PR DESCRIPTION
This PR documents the BLE compatibility of the ESP32 which has been available since 2018.
See: https://github.com/espruino/Espruino/issues/1208#issuecomment-388790168

Why in four years apparently none of the ESP32 Espruino users bothered to update the docs is honestly beyond me

Apart from that, I've also replaced all non-breaking spaces with regular ones in the `Other Boards.md` as they seemed to be there by accident and not on purpose.
And finally, all encountered tables have been reformatted
