### PR TITLE
Add onWrite to ble_midi.js

### DIFF
--- a/modules/ble_midi.js
+++ b/modules/ble_midi.js
@@ -3,6 +3,7 @@
 var midi = require("ble_midi");
 midi.init();
 
+midi.on('midi', console.log);
 midi.send(channel, controller, value);
 */
 
@@ -14,7 +15,8 @@ exports.init = function() {
         readable: true,
         writable: true,
         notify: true,
-        value: [0x80, 0x80, 0x00, 0x00, 0x00]
+        value: [0x80, 0x80, 0x00, 0x00, 0x00],
+        onWrite: function(evt) { exports.emit('midi', evt.data); }
       }
     }
   });


### PR DESCRIPTION
Changes:
* Implement onWrite and emit received data

I tested this with a simple program that receives note events and echoes the same events a 5th higher.

```js
var midi = require('https://raw.githubusercontent.com/joebowbeer/EspruinoDocs/patch-1/modules/ble_midi.js');
midi.init();

midi.on('midi', function(data) {
  var cmd = data[2] & 0xF0; // command
  var chn = data[2] & 0x0F; // channel
  switch(cmd) {
    case 0x80: // noteOff
    case 0x90: // noteOn
      var num = data[3];
      var val = data[4];
      if (val) LED3.set(); else LED3.reset();
      midi.cmd(cmd+chn, num+7, val);
      break;
  }
});
```