### PR TITLE
changed the python version for the build and updated buffer commands

### DIFF
--- a/bin/fontpreview.js
+++ b/bin/fontpreview.js
@@ -2,7 +2,7 @@
 /* Creates a URL-encoded preview image of an Espruino bitmap font */
 
 global.atob = function(a) {
-    return new Buffer(a, 'base64').toString('binary');
+    return Buffer.from(a, 'base64').toString('binary');
 };
 
 function getFontPreview(path) {
@@ -152,7 +152,7 @@ function getFontPreview(path) {
     console.log(s);
   }*/
   // Output URL encoded
-  return "data:image/bmp;base64,"+new Buffer(imgData).toString('base64');
+  return "data:image/bmp;base64,"+ Buffer.from(imgData).toString('base64');
 }
 
 //console.log(getFontPreview("../modules/FontDennis8.js"));

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ done
 cp boards/img/PUCKJS_2.jpg $DIR/html/img
 cp boards/img/PUCKJS_LITE.jpg $DIR/html/img
 # Now do a full build_docs - this will update function_keywords.js that build.js needs
-python2.7 scripts/build_docs.py
+python scripts/build_docs.py
 
 cd $DIR
 


### PR DESCRIPTION
Since Espruino build script moved to python3.  The docs build scripts that call it also need to be updated.
https://github.com/espruino/Espruino/pull/2441


Also NodeJS "new Buffer(number)" is depreciated in NodeJS
https://stackoverflow.com/questions/52165333/deprecationwarning-buffer-is-deprecated-due-to-security-and-usability-issues