### PR TITLE
Bangle.js App Loader: link App Contribution wiki

### DIFF
--- a/tutorials/Bangle.js App Loader.md
+++ b/tutorials/Bangle.js App Loader.md
@@ -217,3 +217,6 @@ More Info
 There are a more [Bangle.js tutorials](/Bangle.js#tutorials) on making apps.
 
 For a reference of the format of apps and the JSON, check out [the Bangle.js App Loader's README file](https://github.com/espruino/BangleApps)
+
+Maintainers of the [espruino/BangleApps](https://github.com/espruino/BangleApps/) repository uses the [App Contribution](https://github.com/espruino/BangleApps/wiki/App-Contribution)
+checklist as an aid when reviewing pull requests.


### PR DESCRIPTION
> Oh sorry, didn't see that page, might be a good idea to mention the [App Contribution wiki page] in the [add app](https://www.espruino.com/Bangle.js+App+Loader) page [...]

_Originally posted by @Hairo in https://github.com/espruino/BangleApps/issues/2847#issuecomment-1868154612_
            