### PR TITLE
fixed a cors problem when serving files locally

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,19 +1,26 @@
 /* node.js script that creates a webserver to serve up the pages from the html directory */
 
 var express = require('express');
+const cors = require('cors');
+const homeDirectory = require('os').homedir();
 var app = express();
+app.use(cors());
 
 app.all('/*', function(req, res, next) {
   // The root page is part of the large site and so is not available
   // locally. Instead we default to a given page to kick off.
+  var urlLocation = __dirname + '/html';
   if (req.url === '/') {
     res.redirect('/Original.html');
     return next();
   } else if (!req.url.match(/.*\/?\./)) {
     req.url += '.html';
+  } else if (req.url.match(/^\/modules\//)){
+    console.log("got here")
+    urlLocation = homeDirectory + "/workspace/espruinowebsite/www";
   }
   console.log('returning: ' + req.url);
-  return express.static(__dirname + '/html')(req, res, next);
+  return express.static(urlLocation)(req, res, next);
 });
 
 app.listen(process.env.PORT || 3040, function(app){

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "acorn": "^6.0.2",
     "acorn-walk": "^6.1.0",
+    "cors": "^2.8.5",
     "eslint": "^5.14.1",
     "express": "^4.13.3",
     "highlight.js": "^8.9.1",


### PR DESCRIPTION
So this does two things.  The module files don't get served with the server because there built in a different directory.  

Then there seems to be a CORS problem.  I'm guessing because the ide has a origin of **https://www.espruino.com** and the express server just rejects it.  So i just set it to allow anyone to receive the file.  

Fixes this error
Access to fetch at '[http://localhost:3040/modules/BH1792.min­.js'](http://microcosm.app/out/Zb5Si) from
origin '[https://www.espruino.com'](http://microcosm.app/out/5c5Si) has been blocked by CORS policy: No
'Access-Control-Allow-Origin' header is present on the requested
resource. If an opaque response serves your needs, set the request's
mode to 'no-cors' to fetch the resource with CORS disabled.
