### PR TITLE
Add library for decoding the Quite Ok Audio Format (QOA)

### DIFF
--- a/modules/QOA.js
+++ b/modules/QOA.js
@@ -1,0 +1,599 @@
+/*
+Copyright (c) 2025 Simon Sievert
+SPDX-License-Identifier: MIT
+*/
+
+/*
+Library for working with the [Quite Ok Audio Format (QOA)](https://qoaformat.org).
+*/
+
+let qoa = E.compiledC(`
+//int SAMPLES_PER_FRAME()
+//int ENCODED_FRAME_SIZE_BYTES()
+//int MIN_FILESIZE()
+//int DECODER_STATE_SIZE()
+//void set_decoder_state_buf(int)
+//void set_use_16_bit(bool)
+//bool get_use_16_bit()
+//int get_last_frame_len()
+//void fill_with_silence(int, int)
+//int decode_header(int, int)
+//int get_sample_rate()
+//int get_total_samples()
+//int decode_frame(int, int, int)
+//void copy_data(int, int, int)
+//void clear_buf(int, int)
+
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef signed short int16_t;
+typedef unsigned short uint16_t;
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+
+typedef unsigned int size_t;
+
+/*
+ * Copyright (c) 2023, Dominic Szablewski - https://phoboslab.org
+ * SPDX-License-Identifier: MIT
+ *
+ * QOA - The "Quite OK Audio" format for fast, lossy audio compression
+ */
+
+
+static const uint32_t QOA_MIN_FILESIZE = 16;
+static const uint32_t QOA_MAX_CHANNELS = 8;
+
+static const uint32_t QOA_SLICE_LEN = 20;
+static const uint32_t QOA_SLICES_PER_FRAME = 256;
+static const uint32_t QOA_FRAME_LEN = (QOA_SLICES_PER_FRAME * QOA_SLICE_LEN);
+static const uint32_t QOA_LMS_LEN = 4;
+static const uint32_t QOA_MAGIC = 0x716f6166; /* 'qoaf' */
+
+uint32_t QOA_FRAME_SIZE(uint32_t channels, uint32_t slices) {
+  return 8 + QOA_LMS_LEN * 4 * channels + 8 * slices * channels;
+}
+
+typedef struct {
+  int history[QOA_LMS_LEN];
+  int weights[QOA_LMS_LEN];
+} qoa_lms_t;
+
+typedef struct {
+  unsigned int channels;
+  unsigned int samplerate;
+  unsigned int samples;
+  qoa_lms_t lms[QOA_MAX_CHANNELS];
+} qoa_desc;
+
+unsigned int qoa_decode_header(const unsigned char *bytes, int size, qoa_desc *qoa);
+
+unsigned int qoa_decode_frame(const unsigned char *bytes, unsigned int size, qoa_desc *qoa, short *sample_data, unsigned int *frame_len);
+
+
+/* -----------------------------------------------------------------------------
+    Implementation */
+
+typedef unsigned long long qoa_uint64_t;
+
+/* The dequant_tab maps each of the scalefactors and quantized residuals to
+their unscaled & dequantized version.
+
+Since qoa_div rounds away from the zero, the smallest entries are mapped to 3/4
+instead of 1. The dequant_tab assumes the following dequantized values for each
+of the quant_tab indices and is computed as:
+float dqt[8] = {0.75, -0.75, 2.5, -2.5, 4.5, -4.5, 7, -7};
+dequant_tab[s][q] <- round_ties_away_from_zero(scalefactor_tab[s] * dqt[q])
+
+The rounding employed here is "to nearest, ties away from zero",  i.e. positive
+and negative values are treated symmetrically.
+*/
+
+// note: this is a modified version that uses a quarter of the storage the original one used
+
+static const int16_t qoa_dequant_tab[16][4] = {
+  {  1,     3,    5,     7},
+  {  5,    18,   32,    49},
+  { 16,    53,   95,   147},
+  { 34,   113,  203,   315},
+  { 63,   210,  378,   588},
+  { 104,  345,  621,   966},
+  { 158,  528,  950,  1477},
+  { 228,  760, 1368,  2128},
+  { 316, 1053, 1895,  2947},
+  { 422, 1405, 2529,  3934},
+  { 548, 1828, 3290,  5117},
+  { 696, 2320, 4176,  6496},
+  { 868, 2893, 5207,  8099},
+  {1064, 3548, 6386,  9933},
+  {1286, 4288, 7718, 12005},
+  {1536, 5120, 9216, 14336},
+};
+
+
+/* The Least Mean Squares Filter is the heart of QOA. It predicts the next
+sample based on the previous 4 reconstructed samples. It does so by continuously
+adjusting 4 weights based on the residual of the previous prediction.
+
+The next sample is predicted as the sum of (weight[i] * history[i]).
+
+The adjustment of the weights is done with a "Sign-Sign-LMS" that adds or
+subtracts the residual to each weight, based on the corresponding sample from
+the history. This, surprisingly, is sufficient to get worthwhile predictions.
+
+This is all done with fixed point integers. Hence the right-shifts when updating
+the weights and calculating the prediction. */
+
+static int qoa_lms_predict(qoa_lms_t *lms) {
+  int prediction = 0;
+  for (int i = 0; i < QOA_LMS_LEN; i++) {
+    prediction += lms->weights[i] * lms->history[i];
+  }
+  return prediction >> 13;
+}
+
+static void qoa_lms_update(qoa_lms_t *lms, int sample, int residual) {
+  int delta = residual >> 4;
+  for (int i = 0; i < QOA_LMS_LEN; i++) {
+    lms->weights[i] += lms->history[i] < 0 ? -delta : delta;
+  }
+
+  for (int i = 0; i < QOA_LMS_LEN - 1; i++) {
+    lms->history[i] = lms->history[i + 1];
+  }
+  lms->history[QOA_LMS_LEN - 1] = sample;
+}
+
+static inline int qoa_clamp(int v, int min, int max) {
+  if (v < min) { return min; }
+  if (v > max) { return max; }
+  return v;
+}
+
+/* This specialized clamp function for the signed 16 bit range improves decode
+performance quite a bit. The extra if() statement works nicely with the CPUs
+branch prediction as this branch is rarely taken. */
+
+static inline int qoa_clamp_s16(int v) {
+  if ((unsigned int) (v + 32768) > 65535) {
+    if (v < -32768) { return -32768; }
+    if (v > 32767) { return 32767; }
+  }
+  return v;
+}
+
+static inline qoa_uint64_t qoa_read_u64(const unsigned char *bytes, unsigned int *p) {
+  bytes += *p;
+  *p += 8;
+  return ((qoa_uint64_t) (bytes[0]) << 56) | ((qoa_uint64_t) (bytes[1]) << 48) | ((qoa_uint64_t) (bytes[2]) << 40) |
+         ((qoa_uint64_t) (bytes[3]) << 32) | ((qoa_uint64_t) (bytes[4]) << 24) | ((qoa_uint64_t) (bytes[5]) << 16) |
+         ((qoa_uint64_t) (bytes[6]) << 8) | ((qoa_uint64_t) (bytes[7]) << 0);
+}
+
+
+/* -----------------------------------------------------------------------------
+    Decoder */
+
+unsigned int qoa_decode_header(const unsigned char *bytes, int size, qoa_desc *qoa) {
+  unsigned int p = 0;
+  if (size < QOA_MIN_FILESIZE) {
+    return 0;
+  }
+
+
+  /* Read the file header, verify the magic number ('qoaf') and read the
+  total number of samples. */
+  qoa_uint64_t file_header = qoa_read_u64(bytes, &p);
+
+  if ((file_header >> 32) != QOA_MAGIC) {
+    return 0;
+  }
+
+  qoa->samples = file_header & 0xffffffff;
+  if (!qoa->samples) {
+    return 0;
+  }
+
+  /* Peek into the first frame header to get the number of channels and
+  the samplerate. */
+  qoa_uint64_t frame_header = qoa_read_u64(bytes, &p);
+  qoa->channels = (frame_header >> 56) & 0x0000ff;
+  qoa->samplerate = (frame_header >> 32) & 0xffffff;
+
+  if (qoa->channels == 0 || qoa->samples == 0 || qoa->samplerate == 0) {
+    return 0;
+  }
+
+  return 8;
+}
+
+unsigned int qoa_decode_frame(const unsigned char *bytes, unsigned int size, qoa_desc *qoa, uint8_t *sample_data, unsigned int *frame_len, bool use16Bit) {
+  unsigned int p = 0;
+  *frame_len = 0;
+
+  if (size < 8 + QOA_LMS_LEN * 4 * qoa->channels) {
+    return 0;
+  }
+
+  /* Read and verify the frame header */
+  qoa_uint64_t frame_header = qoa_read_u64(bytes, &p);
+  unsigned int channels = (frame_header >> 56) & 0x0000ff;
+  unsigned int samplerate = (frame_header >> 32) & 0xffffff;
+  unsigned int samples = (frame_header >> 16) & 0x00ffff;
+  unsigned int frame_size = (frame_header) & 0x00ffff;
+
+  unsigned int data_size = frame_size - 8 - QOA_LMS_LEN * 4 * channels;
+  unsigned int num_slices = data_size / 8;
+  unsigned int max_total_samples = num_slices * QOA_SLICE_LEN;
+
+  if (channels != qoa->channels || samplerate != qoa->samplerate || frame_size > size ||
+      samples * channels > max_total_samples) {
+    return 0;
+  }
+
+
+  /* Read the LMS state: 4 x 2 bytes history, 4 x 2 bytes weights per channel */
+  for (unsigned int c = 0; c < channels; c++) {
+    qoa_uint64_t history = qoa_read_u64(bytes, &p);
+    qoa_uint64_t weights = qoa_read_u64(bytes, &p);
+    for (int i = 0; i < QOA_LMS_LEN; i++) {
+      qoa->lms[c].history[i] = ((signed short) (history >> 48));
+      history <<= 16;
+      qoa->lms[c].weights[i] = ((signed short) (weights >> 48));
+      weights <<= 16;
+    }
+  }
+
+
+  /* Decode all slices for all channels in this frame */
+  for (unsigned int sample_index = 0; sample_index < samples; sample_index += QOA_SLICE_LEN) {
+    for (unsigned int c = 0; c < channels; c++) {
+      qoa_uint64_t slice = qoa_read_u64(bytes, &p);
+
+      int scalefactor = (slice >> 60) & 0xf;
+      slice <<= 4;
+
+      int slice_start = sample_index * channels + c;
+      int slice_end = qoa_clamp(sample_index + QOA_SLICE_LEN, 0, samples) * channels + c;
+
+      for (int si = slice_start; si < slice_end; si += channels) {
+        int predicted = qoa_lms_predict(&qoa->lms[c]);
+        int quantized = (slice >> 61) & 0x7;
+        int dequantized = qoa_dequant_tab[scalefactor][quantized / 2];
+        if (quantized % 2 == 1) {
+          dequantized = -dequantized;
+        }
+        int reconstructed = qoa_clamp_s16(predicted + dequantized);
+
+        if (use16Bit) {
+          uint16_t value = (uint16_t) reconstructed ^ 0x8000;
+          ((uint16_t*)sample_data)[si] = value;
+        } else {
+          uint8_t value = ((uint16_t) reconstructed ^ 0x8000) >> 8;
+          sample_data[si] = value;
+        }
+        slice <<= 3;
+
+        qoa_lms_update(&qoa->lms[c], reconstructed, dequantized);
+      }
+    }
+  }
+
+  *frame_len = samples;
+  return p;
+}
+
+
+/*
+ * Wrapper for calling stuff from Espruino
+ */
+
+int SAMPLES_PER_FRAME() { return (int) QOA_FRAME_LEN; }
+
+int ENCODED_FRAME_SIZE_BYTES() { return (int) QOA_FRAME_SIZE(1, QOA_SLICES_PER_FRAME); }
+
+int MIN_FILESIZE() { return (int) QOA_MIN_FILESIZE; }
+
+typedef struct decoder_state {
+  qoa_desc qoaState{};
+  bool use16Bit = false;
+  unsigned int lastFrameLen = 0;
+};
+
+struct decoder_state *decoderState = 0;
+
+int DECODER_STATE_SIZE() { return sizeof(struct decoder_state); }
+
+void set_decoder_state_buf(uint8_t *buf) { decoderState = (struct decoder_state *) buf; }
+
+void set_use_16_bit(bool use16Bit) {
+  if (decoderState == 0) {
+    return;
+  }
+  decoderState->use16Bit = use16Bit;
+}
+
+bool get_use_16_bit() {
+  if (decoderState == 0) {
+    return false;
+  }
+  return decoderState->use16Bit;
+}
+
+int get_last_frame_len() {
+  if (decoderState == 0) {
+    return -1;
+  }
+  return (int) (decoderState->lastFrameLen);
+}
+
+void fill_with_silence(uint8_t *bytes, int numSamples) {
+  if (decoderState == 0) {
+    return;
+  }
+  if (decoderState->use16Bit) {
+    for (size_t i = 0; i < numSamples; i++) {
+      ((uint16_t *) bytes)[i] = 1 << 15;
+    }
+  } else {
+    for (size_t i = 0; i < numSamples; i++) {
+      bytes[i] = 1 << 7;
+    }
+  }
+}
+
+int decode_header(const unsigned char *bytes, int size) {
+  if (decoderState == 0) {
+    return -1;
+  }
+  return (int) qoa_decode_header(bytes, size, &(decoderState->qoaState));
+}
+
+int get_sample_rate() {
+  if (decoderState == 0) {
+    return -1;
+  }
+  return (int) decoderState->qoaState.samplerate;
+}
+
+int get_total_samples() {
+  if (decoderState == 0) {
+    return -1;
+  }
+  return (int) decoderState->qoaState.samples;
+}
+
+int decode_frame(const unsigned char *bytes, unsigned int size, uint8_t *sample_data) {
+  if (decoderState == 0) {
+    return -1;
+  }
+  return (int) qoa_decode_frame(bytes, size, &(decoderState->qoaState), sample_data, &(decoderState->lastFrameLen),
+                                decoderState->use16Bit);
+}
+
+void copy_data(uint8_t *dest, const uint8_t *src, const int numBytes) {
+  for (int i = 0; i < numBytes; i++) {
+    dest[i] = src[i];
+  }
+}
+
+void clear_buf(uint8_t *buf, const int numBytes) {
+  for (int i = 0; i < numBytes; i++) {
+    buf[i] = 0;
+  }
+}
+`);
+
+exports.SAMPLES_PER_FRAME = qoa.SAMPLES_PER_FRAME();
+exports.ENCODED_FRAME_SIZE_BYTES = qoa.ENCODED_FRAME_SIZE_BYTES();
+exports.MIN_FILESIZE = qoa.MIN_FILESIZE();
+
+exports.DECODER_STATE_SIZE = qoa.DECODER_STATE_SIZE();
+
+exports.initDecode = function (headerBuf, options) {
+  options = options || {};
+
+  let decoderStateBuf;
+  // allow reusing decoder state buffer
+  if (options.state !== undefined) {
+    if (options.state.length != exports.DECODER_STATE_SIZE) {
+      throw new Error("Passed decoder state buffer has wrong size");
+    }
+    decoderStateBuf = options.state;
+  } else {
+    decoderStateBuf = new Uint8Array(exports.DECODER_STATE_SIZE);
+    if (decoderStateBuf === undefined) {
+      throw new Error("Failed to allocate decoder state buffer");
+    }
+  }
+  let decoderStateBufPtr = E.getAddressOf(decoderStateBuf, true);
+  if (decoderStateBufPtr == 0) throw new Error("Failed to get pointer to decoder state buffer");
+  qoa.clear_buf(decoderStateBufPtr, exports.DECODER_STATE_SIZE);
+  qoa.set_decoder_state_buf(decoderStateBufPtr);
+
+  let use16Bit = false;
+  if (options.bits !== undefined) {
+    use16Bit = options.bits == 16;
+  }
+  qoa.set_use_16_bit(use16Bit);
+
+  let headerBufPtr = E.getAddressOf(headerBuf, true);
+  if (headerBufPtr == 0) throw new Error("Failed to get pointer to header data buffer. Maybe not a flat string?");
+  let firstFramePos = qoa.decode_header(headerBufPtr, headerBuf.length);
+  if (firstFramePos <= 0) {
+    throw new Error("Failed to decode header");
+  }
+  let sampleRate = qoa.get_sample_rate();
+  let totalSamples = qoa.get_total_samples();
+  let durationSeconds = totalSamples / sampleRate;
+  return {
+    state: decoderStateBuf,
+    firstFramePos: firstFramePos,
+    sampleRate: sampleRate,
+    totalSamples: totalSamples,
+    durationSeconds: durationSeconds
+  };
+};
+
+exports.decode = function (encoded, decoded, state, options) {
+  options = options || {};
+
+  if (state.length != exports.DECODER_STATE_SIZE) {
+    throw new Error("Passed decoder state buffer has wrong size");
+  }
+  let statePtr = E.getAddressOf(state, true);
+  if (statePtr == 0) throw new Error("Failed to get pointer to decoder state buffer");
+  qoa.set_decoder_state_buf(statePtr);
+
+  let fill = false;
+  if (options.fill) {
+    fill = true;
+  }
+
+  let encodedPtr = E.getAddressOf(encoded, true);
+  if (encodedPtr == 0) throw new Error("Failed to get pointer to encoded data buffer. Maybe not a flat string?");
+  let decodedPtr = E.getAddressOf(decoded, true);
+  if (decodedPtr == 0) throw new Error("Failed to get pointer to decoded data buffer. Maybe not a flat string?");
+
+  let bytesPerSample = qoa.get_use_16_bit() ? 2 : 1;
+  if (decoded.length < exports.SAMPLES_PER_FRAME * bytesPerSample) throw new Error("Decoded data buffer is not big enough to hold one frame");
+
+  let readBytes = qoa.decode_frame(encodedPtr, encoded.length, decodedPtr);
+  if (readBytes < 0) throw new Error("Failed to decode frame");
+  let writtenSamples = qoa.get_last_frame_len();
+  if (fill && writtenSamples * bytesPerSample < decoded.length) {
+    qoa.fill_with_silence(decodedPtr + writtenSamples * bytesPerSample, (decoded.length / bytesPerSample) - writtenSamples);
+  }
+  return {readBytes: readBytes, writtenSamples: writtenSamples};
+};
+
+exports.play = function (filename, options) {
+  options = options || {};
+
+  let bytesPerSample = options.bytesPerSample !== undefined ? options.bytesPerSample : 1;
+  if ((bytesPerSample != 1) && (bytesPerSample != 2)) {
+    throw new Error("Invalid bytes per sample, can only be either 1 or 2, but you passed: " + bytesPerSample);
+  }
+  let loop = options.loop !== undefined ? options.loop : false;
+  let loopCount = options.loopCount !== undefined ? options.loopCount : -1;
+
+  let bitsPerSample = bytesPerSample * 8;
+
+  let s = require("Storage");
+  let headerBuf = E.toFlatString(s.read(filename, 0, exports.MIN_FILESIZE));
+  if (headerBuf === undefined) throw new Error("Failed to allocate buffer for header data");
+
+  let initResult = exports.initDecode(headerBuf, {bits: bitsPerSample});
+  headerBuf = undefined;
+
+  let state = initResult.state;
+  let firstFramePos = initResult.firstFramePos;
+  let sampleRate = initResult.sampleRate;
+  let durationSeconds = initResult.durationSeconds;
+
+  let p = firstFramePos;
+
+  let decodedDataBuf = new Uint8Array(exports.SAMPLES_PER_FRAME * bytesPerSample);
+  if (decodedDataBuf === undefined) throw new Error("Failed to allocate decoded data buffer");
+  let decodedDataBufPtr = E.getAddressOf(decodedDataBuf, true);
+  if (decodedDataBufPtr == 0) throw new Error("Failed to get address of decoded data buffer");
+  let decodedDataBufSize = 0;
+  let decodedDataBufIndex = 0;
+
+  let decodeFrame = function () {
+    let encoded = E.toFlatString(s.read(filename, p, exports.ENCODED_FRAME_SIZE_BYTES));
+    let decodeResult = exports.decode(encoded, decodedDataBuf, state);
+    p += decodeResult.readBytes;
+    decodedDataBufSize = decodeResult.writtenSamples * bytesPerSample;
+    decodedDataBufIndex = 0;
+    return decodeResult.writtenSamples;
+  };
+
+  let nextBuffer = function (buf) {
+    let bufPtr = E.getAddressOf(buf, true);
+    if (bufPtr == 0) throw new Error("Failed to get address of decoded data buffer");
+    let bufIndex = 0;
+    let bufSizeBytes = buf.length * bytesPerSample;
+    while (bufIndex < bufSizeBytes) {
+      let alreadyDecodedBytes = decodedDataBufSize - decodedDataBufIndex;
+      if (alreadyDecodedBytes > 0) {
+        let neededBytes = bufSizeBytes - bufIndex;
+        let copyBytes = alreadyDecodedBytes < neededBytes ? alreadyDecodedBytes : neededBytes;
+        qoa.copy_data(bufPtr + bufIndex, decodedDataBufPtr + decodedDataBufIndex, copyBytes);
+        decodedDataBufIndex += copyBytes;
+        bufIndex += copyBytes;
+      } else {
+        let decodedSamples = decodeFrame();
+        if (decodedSamples == 0) {
+          // no more samples
+          if (loopCount > 0) {
+            loopCount--;
+          }
+          if (loop && (loopCount == 0)) {
+            loop = false;
+          }
+          if (loop) {
+            p = firstFramePos;
+          } else {
+            if (bufIndex < bufSizeBytes) {
+              qoa.fill_with_silence(bufPtr + bufIndex, (bufSizeBytes - bufIndex) / bytesPerSample);
+            }
+            return bufIndex;
+          }
+        }
+      }
+    }
+    return bufIndex;
+  };
+
+  let outputType = options.output !== undefined ? options.output : "waveform";
+  let outputOptions = options.outputOptions || {};
+
+  if (outputType == "waveform") {
+    let w = new Waveform(2048 * bytesPerSample, {doubleBuffer: true, bits: bitsPerSample});
+    if (outputOptions.pin == undefined) {
+      throw new Error("missing output option: pin");
+    }
+    let outPin = outputOptions.pin;
+    let outPinNeg = outputOptions.pin_neg !== undefined ? outputOptions.pin_neg : undefined;
+    analogWrite(outPin, 0.5, {freq: sampleRate * 10});
+    if (outPinNeg !== undefined) {
+      analogWrite(outPinNeg, 0.5, {freq: sampleRate * 10});
+    }
+
+    nextBuffer(w.buffer);
+    nextBuffer(w.buffer2);
+
+    let stopOnNextBufferCallback = false;
+    w.on("buffer", (buf) => {
+      let writtenSamples = nextBuffer(buf);
+      if (stopOnNextBufferCallback) {
+        w.stop();
+      }
+      if (writtenSamples == 0) {
+        stopOnNextBufferCallback = true;
+      }
+    });
+
+    w.on("finish", () => {
+      outPin.read();
+      if (outPinNeg !== undefined) {
+        outPinNeg.read();
+      }
+      if (options.onFinish !== undefined) {
+        options.onFinish();
+      }
+    });
+
+    w.startOutput(outPin, sampleRate, {pin_neg: outPinNeg, repeat: true});
+
+    return {
+      durationSeconds: durationSeconds,
+      stop: () => {
+        w.stop();
+      }
+    };
+  } else {
+    throw new Error("Unknown output type: " + outputType);
+  }
+};

--- a/modules/QOA.md
+++ b/modules/QOA.md
@@ -1,0 +1,670 @@
+<!--- Copyright (c) 2025 Simon Sievert. See the file LICENSE for copying permission. -->
+QOA Library
+==============
+
+<span style="color:red">:warning: **Please view the correctly rendered version of this page
+at https://www.espruino.com/QOA. Links, lists, videos, search, and other features will not work correctly when viewed on
+GitHub** :warning:</span>
+
+* KEYWORDS: Module,Modules,QOA,Audio,Sound
+* USES: Waveform,Speaker
+
+Library for working with the [Quite Ok Audio Format (QOA)](https://qoaformat.org).
+
+QOA does reasonably fast lossy audio compression at 3.2 bits per sample.
+
+This library currently supports decoding QOA-encoded audio on any board that you can upload inline C to.  
+Sound can then be played back with the [[Waveform]] class.
+
+Encode some audio
+-----------------
+
+To encode some audio, you can either use the form on this web page and let your browser do the heavy lifting,
+or compile and use the [reference encoder](https://github.com/phoboslab/qoa).
+
+Using the in-browser method is rather straightforward:  
+Just select a file and a "download" popup should appear a moment later (everything runs locally in your browser).  
+This downsamples your audio file to the selected sample rate (default is 8000 Hz), converts it to mono and encodes it.
+
+<table>
+    <tbody>
+    <tr>
+        <td><label for="fileInput">Audio File:</label></td>
+        <td><input id="fileInput" type="file"></td>
+    </tr>
+    <tr>
+        <td><label for="sampleRateInput">Sample Rate (Hz):</label></td>
+        <td><input id="sampleRateInput" type="number" value="8000"></td>
+    </tr>
+    </tbody>
+</table>
+
+Using the reference encoder is a bit more work, mainly because you need to compile it
+and downsample and covert your audio to mono before passing it to the encoder yourself.
+
+Starting with an audio file "audio.mp3", you can create a QOA file,
+using ffmpeg to do the downsampling and mono conversion,
+like this:
+
+```bash
+ffmpeg -i audio.mp3 -ar 8000 -ac 1 audio.wav
+./qoaconv audio.wav audio.qoa
+```
+
+Decoding and playback
+---------------------
+
+To play a file called "audio.qoa" from storage on Jolt.js, using the Waveform class, with a speaker connected to `H0` and `H1`, you can do:
+
+```js
+let qoa = require("QOA");
+let handle = qoa.play("audio.qoa", {output: "waveform", outputOptions: {pin: H0, pin_neg: H1}});
+```
+
+The `handle` is an object of the form:
+- `durationSeconds` - integer, duration of the audio in seconds
+- `stop` - function, can be called to stop playback
+
+You can also loop the file three times, and do something once playback finishes:
+
+```js
+let qoa = require("QOA");
+let handle = qoa.play("audio.qoa", {loop:1, loopCount: 3, output: "waveform", outputOptions: {pin: H0, pin_neg: H1}, onFinish: () => {print("playback finished");}});
+```
+
+The `play()` function accepts the following arguments:
+- `filename` - string, name of a file that can be read from storage
+- `options` - object, containing additional options
+  - `output` - string, name of the output method to use; currently only "waveform" is supported
+  - `outputOptions` - object, additional options for the output method
+    - in the case of `output: "waveform"`:
+      - `pin`: pin, speaker pin; like for example `H0` on Jolt.js
+      - `pin_neg`: pin, optional second speaker pin; like for example `H1` on Jolt.js
+  - `loop` - boolean, whether to automagically restart playback at the beginning once it reaches the end of the file
+  - `loopCount` - integer, optional number of times to loop the audio; minimum is one, default is to loop forever
+  - `bytesPerSample` - integer, default is `1`, but you can also use `2` for 16 bits per sample mode (which might sound better, but will use more RAM)
+  - `onFinish` - function, will be called when playback is done
+
+You need to give it at least a filename, and a `pin`.
+
+If something goes wrong, `play()` will throw an exception.
+
+If you want to do the decoding yourself, for example to output audio using something other than the Waveform class, you are free to do so, but it's a tad more involved:
+
+```js
+let qoa = require("QOA");
+let filename = "audio.qoa";
+
+let play = function () {
+    let bytesPerSample = 1;
+    
+    let bitsPerSample = bytesPerSample * 8;
+
+    let s = require("Storage");
+    
+    let headerBuf = E.toFlatString(s.read(filename, 0, qoa.MIN_FILESIZE));
+    if (headerBuf === undefined) throw new Error("Failed to allocate buffer for header data");
+    let initResult = qoa.initDecode(headerBuf, {bits: bitsPerSample});
+    headerBuf = undefined;
+    
+    let state = initResult.state;
+    let firstFramePos = initResult.firstFramePos;
+    let sampleRate = initResult.sampleRate;
+    let durationSeconds = initResult.durationSeconds;
+
+    // you are free to choose another buffer size,
+    // but QOA since is decoded in frames with qoa.SAMPLES_PER_FRAME samples each,
+    // sizing your buffer accordingly makes things slightly less complicated
+    // hint: the qoa.play() function uses a different buffer size, to allow gapless looping
+    let bufferSize = qoa.SAMPLES_PER_FRAME * bytesPerSample;
+    let w = new Waveform(bufferSize, {doubleBuffer: true, bits: bitsPerSample});
+    analogWrite(H0, 0.5, {freq: sampleRate * 10});
+    analogWrite(H1, 0.5, {freq: sampleRate * 10});
+    
+    let p = firstFramePos;
+    let nextBuffer = function (buf) {
+        let encoded = E.toFlatString(s.read(filename, p, qoa.ENCODED_FRAME_SIZE_BYTES));
+        // decode into buf, filling leftover space with silence
+        let decodeResult = qoa.decode(encoded, buf, state, {fill: 1});
+        p += decodeResult.readBytes;
+        return decodeResult.writtenSamples;
+    };
+
+    // fill buffers with initial data
+    nextBuffer(w.buffer);
+    nextBuffer(w.buffer2);
+
+    let stopOnNextBufferCallback = false;
+    w.on("buffer", (buf) => {
+        let decodedSamples = nextBuffer(buf);
+        if (stopOnNextBufferCallback) {
+            w.stop();
+        }
+        if (decodedSamples == 0) {
+            stopOnNextBufferCallback = true;
+        }
+    });
+
+    w.startOutput(H0, sampleRate, {pin_neg: H1, repeat: true});
+
+    w.on("finish", () => {
+        H0.read();
+        H1.read();
+    });
+};
+
+setWatch(function () {
+    play();
+}, BTN, {repeat: true});
+
+play();
+```
+
+<!-- QOA encode/decode in js for encoding files in the browser -->
+<script type="text/template" id="qoaModule">
+    // Copyright (C) 2023-2024 Piotr Fusik
+    // SPDX-License-Identifier: MIT
+    // Source: https://github.com/pfusik/qoa-fu/blob/master/transpiled/QOA.js
+    
+    // Generated automatically with "fut". Do not edit.
+    
+    /**
+     * Least Mean Squares Filter.
+     */
+    class LMS
+    {
+        history = new Int32Array(4);
+        weights = new Int32Array(4);
+    
+        assign(source)
+        {
+            this.history.set(source.history);
+            this.weights.set(source.weights);
+        }
+    
+        predict()
+        {
+            return (this.history[0] * this.weights[0] + this.history[1] * this.weights[1] + this.history[2] * this.weights[2] + this.history[3] * this.weights[3]) >> 13;
+        }
+    
+        update(sample, residual)
+        {
+            let delta = residual >> 4;
+            this.weights[0] += this.history[0] < 0 ? -delta : delta;
+            this.weights[1] += this.history[1] < 0 ? -delta : delta;
+            this.weights[2] += this.history[2] < 0 ? -delta : delta;
+            this.weights[3] += this.history[3] < 0 ? -delta : delta;
+            this.history[0] = this.history[1];
+            this.history[1] = this.history[2];
+            this.history[2] = this.history[3];
+            this.history[3] = sample;
+        }
+    }
+    
+    /**
+     * Common part of the "Quite OK Audio" format encoder and decoder.
+     */
+    export class QOABase
+    {
+        frameHeader;
+    
+        /**
+         * Maximum number of channels supported by the format.
+         */
+        static MAX_CHANNELS = 8;
+    
+        /**
+         * Returns the number of audio channels.
+         */
+        getChannels()
+        {
+            return this.frameHeader >> 24;
+        }
+    
+        /**
+         * Returns the sample rate in Hz.
+         */
+        getSampleRate()
+        {
+            return this.frameHeader & 16777215;
+        }
+    
+        static SLICE_SAMPLES = 20;
+    
+        static MAX_FRAME_SLICES = 256;
+    
+        /**
+         * Maximum number of samples per frame.
+         */
+        static MAX_FRAME_SAMPLES = 5120;
+    
+        getFrameBytes(sampleCount)
+        {
+            let slices = (sampleCount + 19) / 20 | 0;
+            return 8 + this.getChannels() * (16 + slices * 8);
+        }
+    
+        static SCALE_FACTORS = new Int16Array([ 1, 7, 21, 45, 84, 138, 211, 304, 421, 562, 731, 928, 1157, 1419, 1715, 2048 ]);
+    
+        static dequantize(quantized, scaleFactor)
+        {
+            let dequantized;
+            switch (quantized >> 1) {
+                case 0:
+                    dequantized = (scaleFactor * 3 + 2) >> 2;
+                    break;
+                case 1:
+                    dequantized = (scaleFactor * 5 + 1) >> 1;
+                    break;
+                case 2:
+                    dequantized = (scaleFactor * 9 + 1) >> 1;
+                    break;
+                default:
+                    dequantized = scaleFactor * 7;
+                    break;
+            }
+            return (quantized & 1) != 0 ? -dequantized : dequantized;
+        }
+    }
+    
+    /**
+     * Encoder of the "Quite OK Audio" format.
+     */
+    export class QOAEncoder extends QOABase
+    {
+        constructor()
+        {
+            super();
+            for (let _i0 = 0; _i0 < 8; _i0++) {
+                this.#lMSes[_i0] = new LMS();
+            }
+        }
+        #lMSes = new Array(8);
+    
+        /**
+         * Writes the file header.
+         * Returns <code>true</code> on success.
+         * @param totalSamples File length in samples per channel.
+         * @param channels Number of audio channels.
+         * @param sampleRate Sample rate in Hz.
+         */
+        writeHeader(totalSamples, channels, sampleRate)
+        {
+            if (totalSamples <= 0 || channels <= 0 || channels > 8 || sampleRate <= 0 || sampleRate >= 16777216)
+                return false;
+            this.frameHeader = channels << 24 | sampleRate;
+            for (let c = 0; c < channels; c++) {
+                this.#lMSes[c].history.fill(0);
+                this.#lMSes[c].weights[0] = 0;
+                this.#lMSes[c].weights[1] = 0;
+                this.#lMSes[c].weights[2] = -8192;
+                this.#lMSes[c].weights[3] = 16384;
+            }
+            let magic = 1903124838n;
+            return this.writeLong(magic << 32n | BigInt(totalSamples));
+        }
+    
+        #writeLMS(a)
+        {
+            let a0 = BigInt(a[0]);
+            let a1 = BigInt(a[1]);
+            let a2 = BigInt(a[2]);
+            return this.writeLong(a0 << 48n | (a1 & 65535n) << 32n | (a2 & 65535n) << 16n | BigInt(a[3] & 65535));
+        }
+    
+        /**
+         * Encodes and writes a frame.
+         * @param samples PCM samples: <code>samplesCount * channels</code> elements.
+         * @param samplesCount Number of samples per channel.
+         */
+        writeFrame(samples, samplesCount)
+        {
+            if (samplesCount <= 0 || samplesCount > 5120)
+                return false;
+            let header = BigInt(this.frameHeader);
+            if (!this.writeLong(header << 32n | BigInt(samplesCount << 16) | BigInt(this.getFrameBytes(samplesCount))))
+                return false;
+            let channels = this.getChannels();
+            for (let c = 0; c < channels; c++) {
+                if (!this.#writeLMS(this.#lMSes[c].history) || !this.#writeLMS(this.#lMSes[c].weights))
+                    return false;
+            }
+            const lms = new LMS();
+            const bestLMS = new LMS();
+            const lastScaleFactors = new Uint8Array(8);
+            for (let sampleIndex = 0; sampleIndex < samplesCount; sampleIndex += 20) {
+                let sliceSamples = Math.min(samplesCount - sampleIndex, 20);
+                for (let c = 0; c < channels; c++) {
+                    let bestRank = 9223372036854775807n;
+                    let bestSlice = 0n;
+                    for (let scaleFactorDelta = 0; scaleFactorDelta < 16; scaleFactorDelta++) {
+                        let scaleFactor = (lastScaleFactors[c] + scaleFactorDelta) & 15;
+                        lms.assign(this.#lMSes[c]);
+                        let reciprocal = QOAEncoder.#WRITE_FRAME_RECIPROCALS[scaleFactor];
+                        let slice = BigInt(scaleFactor);
+                        let currentRank = 0n;
+                        for (let s = 0; s < sliceSamples; s++) {
+                            let sample = samples[(sampleIndex + s) * channels + c];
+                            let predicted = lms.predict();
+                            let residual = sample - predicted;
+                            let scaled = (residual * reciprocal + 32768) >> 16;
+                            if (scaled != 0)
+                                scaled += scaled < 0 ? 1 : -1;
+                            if (residual != 0)
+                                scaled += residual > 0 ? 1 : -1;
+                            let quantized = QOAEncoder.#WRITE_FRAME_QUANT_TAB[8 + Math.min(Math.max(scaled, -8), 8)];
+                            let dequantized = QOAEncoder.dequantize(quantized, QOAEncoder.SCALE_FACTORS[scaleFactor]);
+                            let reconstructed = Math.min(Math.max(predicted + dequantized, -32768), 32767);
+                            let error = BigInt(sample - reconstructed);
+                            currentRank += error * error;
+                            let weightsPenalty = ((lms.weights[0] * lms.weights[0] + lms.weights[1] * lms.weights[1] + lms.weights[2] * lms.weights[2] + lms.weights[3] * lms.weights[3]) >> 18) - 2303;
+                            if (weightsPenalty > 0)
+                                currentRank += BigInt(weightsPenalty);
+                            if (currentRank >= bestRank)
+                                break;
+                            lms.update(reconstructed, dequantized);
+                            slice = slice << 3n | BigInt(quantized);
+                        }
+                        if (currentRank < bestRank) {
+                            bestRank = currentRank;
+                            bestSlice = slice;
+                            bestLMS.assign(lms);
+                        }
+                    }
+                    this.#lMSes[c].assign(bestLMS);
+                    bestSlice <<= BigInt((20 - sliceSamples) * 3);
+                    lastScaleFactors[c] = Number(bestSlice >> 60n);
+                    if (!this.writeLong(bestSlice))
+                        return false;
+                }
+            }
+            return true;
+        }
+    
+        static #WRITE_FRAME_RECIPROCALS = new Int32Array([ 65536, 9363, 3121, 1457, 781, 475, 311, 216, 156, 117, 90, 71, 57, 47, 39, 32 ]);
+    
+        static #WRITE_FRAME_QUANT_TAB = new Uint8Array([ 7, 7, 7, 5, 5, 3, 3, 1, 0, 0, 2, 2, 4, 4, 6, 6,
+            6 ]);
+    }
+    
+    /**
+     * Decoder of the "Quite OK Audio" format.
+     */
+    export class QOADecoder extends QOABase
+    {
+        #buffer;
+        #bufferBits;
+    
+        #readBits(bits)
+        {
+            while (this.#bufferBits < bits) {
+                let b = this.readByte();
+                if (b < 0)
+                    return -1;
+                this.#buffer = this.#buffer << 8 | b;
+                this.#bufferBits += 8;
+            }
+            this.#bufferBits -= bits;
+            let result = this.#buffer >> this.#bufferBits;
+            this.#buffer &= (1 << this.#bufferBits) - 1;
+            return result;
+        }
+        #totalSamples;
+        #positionSamples;
+    
+        /**
+         * Reads the file header.
+         * Returns <code>true</code> if the header is valid.
+         */
+        readHeader()
+        {
+            if (this.readByte() != 113 || this.readByte() != 111 || this.readByte() != 97 || this.readByte() != 102)
+                return false;
+            this.#bufferBits = this.#buffer = 0;
+            this.#totalSamples = this.#readBits(32);
+            if (this.#totalSamples <= 0)
+                return false;
+            this.frameHeader = this.#readBits(32);
+            if (this.frameHeader <= 0)
+                return false;
+            this.#positionSamples = 0;
+            let channels = this.getChannels();
+            return channels > 0 && channels <= 8 && this.getSampleRate() > 0;
+        }
+    
+        /**
+         * Returns the file length in samples per channel.
+         */
+        getTotalSamples()
+        {
+            return this.#totalSamples;
+        }
+    
+        #getMaxFrameBytes()
+        {
+            return 8 + this.getChannels() * 2064;
+        }
+    
+        #readLMS(result)
+        {
+            for (let i = 0; i < 4; i++) {
+                let hi = this.readByte();
+                if (hi < 0)
+                    return false;
+                let lo = this.readByte();
+                if (lo < 0)
+                    return false;
+                result[i] = ((hi ^ 128) - 128) << 8 | lo;
+            }
+            return true;
+        }
+    
+        /**
+         * Reads and decodes a frame.
+         * Returns the number of samples per channel.
+         * @param samples PCM samples.
+         */
+        readFrame(samples)
+        {
+            if (this.#positionSamples > 0 && this.#readBits(32) != this.frameHeader)
+                return -1;
+            let samplesCount = this.#readBits(16);
+            if (samplesCount <= 0 || samplesCount > 5120 || samplesCount > this.#totalSamples - this.#positionSamples)
+                return -1;
+            let channels = this.getChannels();
+            let slices = (samplesCount + 19) / 20 | 0;
+            if (this.#readBits(16) != 8 + channels * (16 + slices * 8))
+                return -1;
+            const lmses = new Array(8);
+            for (let _i0 = 0; _i0 < 8; _i0++) {
+                lmses[_i0] = new LMS();
+            }
+            for (let c = 0; c < channels; c++) {
+                if (!this.#readLMS(lmses[c].history) || !this.#readLMS(lmses[c].weights))
+                    return -1;
+            }
+            for (let sampleIndex = 0; sampleIndex < samplesCount; sampleIndex += 20) {
+                for (let c = 0; c < channels; c++) {
+                    let scaleFactor = this.#readBits(4);
+                    if (scaleFactor < 0)
+                        return -1;
+                    scaleFactor = QOADecoder.SCALE_FACTORS[scaleFactor];
+                    let sampleOffset = sampleIndex * channels + c;
+                    for (let s = 0; s < 20; s++) {
+                        let quantized = this.#readBits(3);
+                        if (quantized < 0)
+                            return -1;
+                        if (sampleIndex + s >= samplesCount)
+                            continue;
+                        let dequantized = QOADecoder.dequantize(quantized, scaleFactor);
+                        let reconstructed = Math.min(Math.max(lmses[c].predict() + dequantized, -32768), 32767);
+                        lmses[c].update(reconstructed, dequantized);
+                        samples[sampleOffset] = reconstructed;
+                        sampleOffset += channels;
+                    }
+                }
+            }
+            this.#positionSamples += samplesCount;
+            return samplesCount;
+        }
+    
+        /**
+         * Seeks to the given time offset.
+         * Requires the input stream to be seekable with <code>SeekToByte</code>.
+         * @param position Position from the beginning of the file.
+         */
+        seekToSample(position)
+        {
+            let frame = position / 5120 | 0;
+            this.seekToByte(frame == 0 ? 12 : 8 + frame * this.#getMaxFrameBytes());
+            this.#positionSamples = frame * 5120;
+        }
+    
+        /**
+         * Returns <code>true</code> if all frames have been read.
+         */
+        isEnd()
+        {
+            return this.#positionSamples >= this.#totalSamples;
+        }
+    }
+</script>
+
+<!-- glue code for taking an "uploaded" file, encoding it to qoa and presenting it as something that can be "downloaded" -->
+<script type="module">
+    // Copyright (c) 2025 Simon Sievert
+    // SPDX-License-Identifier: MIT
+    const qoa = await import(
+        URL.createObjectURL(
+            new Blob(
+                [document.getElementById('qoaModule').innerText],
+                {type: 'application/javascript'},
+            )
+        )
+    );
+    
+    const fileInput = document.getElementById("fileInput");
+    const sampleRateInput = document.getElementById("sampleRateInput");
+    fileInput.addEventListener("change", async (event) => {
+        // the base QOAEncoder doesn't know how to write data
+        // extend it with something that does
+        // (data is written to memory; can be fetched with "getData()" when done)
+        class QOAEncoder extends qoa.QOAEncoder {
+            constructor() {
+                super();
+            }
+
+            #data = [];
+            #dataSizeBytes = 0;
+            #currentDataChunk = undefined;
+            #currentDataChunkIndex = 0;
+
+            writeByte(b) {
+                if ((this.#currentDataChunk == undefined) || (this.#currentDataChunkIndex >= this.#currentDataChunk.length)) {
+                    this.#currentDataChunk = new Uint8Array(1024);
+                    this.#currentDataChunkIndex = 0;
+                    this.#data.push(this.#currentDataChunk);
+                }
+                this.#currentDataChunk[this.#currentDataChunkIndex] = b;
+                this.#currentDataChunkIndex++;
+                this.#dataSizeBytes++;
+
+            }
+
+            writeLong(l) {
+                for (let i = 0; i < 8; i++) {
+                    let byte = Number(((l >> BigInt((7 - i) * 8))) & 0xffn);
+                    this.writeByte(byte);
+                }
+                return true;
+            }
+
+            getData() {
+                let buf = new Uint8Array(this.#dataSizeBytes);
+                let writeIndex = 0;
+                for (let dataBuf of this.#data) {
+                    for (let byte of dataBuf) {
+                        if (writeIndex >= this.#dataSizeBytes) {
+                            return buf;
+                        }
+                        buf[writeIndex] = byte;
+                        writeIndex++;
+                    }
+                }
+                return buf;
+            }
+        }
+
+        // our QOAEncoder class that writes data to memory
+        let encoder = new QOAEncoder();
+
+        const file = event.target.files[0];
+        const fileBaseName = file.name.replace(/\.[^\.]*$/, '');
+        const SAMPLERATE = Number(sampleRateInput.value);
+        const offlineAudioContext = new OfflineAudioContext(1, SAMPLERATE * 10/*max buffer length*/, SAMPLERATE);
+
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            offlineAudioContext.decodeAudioData(e.target.result)
+                .then(audioBuffer => {
+                    const bufferLength = audioBuffer.length;
+                    const numberOfChannels = audioBuffer.numberOfChannels;
+
+                    // write header for mono audio
+                    encoder.writeHeader(bufferLength, 1, SAMPLERATE);
+
+                    // get the PCM data from the audio buffer
+                    const pcmDataChannels = [];
+                    for (let i = 0; i < numberOfChannels; i++) {
+                        const pcmData = new Float32Array(bufferLength);
+                        audioBuffer.copyFromChannel(pcmData, i, 0);
+                        pcmDataChannels.push(pcmData);
+                    }
+
+                    // encode in frames with SAMPLES_PER_FRAME samples each
+                    // except for the last frame
+                    const SAMPLES_PER_FRAME = 5120;
+                    const frameSamples = new Int16Array(SAMPLES_PER_FRAME);
+                    let sampleIndex = 0;
+                    while (sampleIndex < bufferLength) {
+                        let frameStartIndex = sampleIndex;
+                        let frameEndIndex = Math.min(frameStartIndex + SAMPLES_PER_FRAME - 1, bufferLength - 1) | 0;
+                        let frameLength = (frameEndIndex - frameStartIndex + 1) | 0;
+                        for (let i = 0; i < frameLength; i++) {
+                            // average value from all channels
+                            let avg = 0.0;
+                            for (let pcmData of pcmDataChannels) {
+                                avg += pcmData[frameStartIndex + i];
+                            }
+                            avg /= numberOfChannels;
+
+                            // convert to 16 bit signed PCM
+                            let v = Math.round(avg * 32767); // we expect this to wrap over negative->positive anyway
+                            if (v < -32768) v = -32768;
+                            if (v > 32767) v = 32767;
+                            frameSamples[i] = v;
+                        }
+                        encoder.writeFrame(frameSamples, frameLength);
+                        // advance to the next frame
+                        sampleIndex = (frameEndIndex + 1) | 0;
+                    }
+
+                    // present encoded data as something that can be downloaded
+                    const encodedData = encoder.getData();
+                    const blob = new Blob([encodedData], {type: "audio/qoa"});
+                    const downloadURL = URL.createObjectURL(blob);
+                    const downloadElement = document.createElement("a");
+                    downloadElement.href = downloadURL;
+                    downloadElement.download = fileBaseName + ".qoa";
+                    document.body.appendChild(downloadElement);
+                    downloadElement.click();
+                    document.body.removeChild(downloadElement);
+                    URL.revokeObjectURL(downloadURL);
+                })
+                .catch(error => {
+                    console.error("Error decoding audio data:", error);
+                });
+        };
+        reader.readAsArrayBuffer(file);
+    });
+</script>


### PR DESCRIPTION
This adds a library for decoding the [Quite Ok Audio Format (QOA)](https://qoaformat.org/), using some inline C and a fancy js wrapper.

QOA does reasonably fast lossy audio compression from 16 bits per sample down to 3.2 bits per sample, and should allow for saving some precious flash.

This PR kind of supersedes https://github.com/espruino/Espruino/pull/2592, since it pretty much does everything that PR did and then some more. (And only uses additional flash if a user wants to decode QOA encoded audio, instead of having to be baked into the firmware, not being used by most and wasting space.)

The docs for the library include a QOA encoder in pure js to make it easier for people to encode their own audio files to QOA. (Thanks for the starter code by the way, that helped a lot! https://github.com/espruino/Espruino/pull/2592#issuecomment-2592105727)
Alternatively, the [reference encoder / decoder](https://github.com/phoboslab/qoa) can be used as well. (The docs for the library describe how to use `ffmpeg` and the reference encoder to produce some 8 kHz mono audio.)

I tested and developed this using Jolt.js with 8 kHz mono audio.

Basic usage looks like this:
```js
let qoa = require("QOA");
qoa.play("audio.qoa", {output: "waveform", outputOptions: {pin: H0, pin_neg: H1}});
```
But for anyone wanting to do the playback themselves, decoding samples to a buffer is exposed as well.

Some (fairly loopable) zipped example files to quickly test playback (zipped because GitHub doesn't allow uploading files ending in `.qoa`):
- [radio.zip](https://github.com/user-attachments/files/19375053/radio.zip)
- [moveIt.zip](https://github.com/user-attachments/files/19375070/moveIt.zip) (if you feel like annoying yourself or someone else)

Weirdly enough, playback is slow and seems choppy when connected via BLE, but is a normal amount of speedy and doesn't seem to be choppy when connected via serial.
I though playback speed was related to the voltage the board is powered at, but the difference when connecting via serial and disconnecting is quite enourmous.

Eventually, I'd like to play audio over I2S for that extra quality boost, but I always seem to run out of time when thinking about hacking I2S support into Espruino. (Which is the reason for adding the `output` option to the `play()` function; to be able to potentially support I2S in the future.)

I'd love to get some feedback on this :)